### PR TITLE
feat(mcp): add ComfyUI MCP server image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         docker buildx bake --file docker-bake.hcl --print | grep -q "runtime-cpu"
         docker buildx bake --file docker-bake.hcl --print | grep -q "runtime-cuda"
         docker buildx bake --file docker-bake.hcl --print | grep -q "complete-cuda"
+        docker buildx bake --file docker-bake.hcl --print | grep -q "mcp"
 
   build-cuda:
     runs-on: ubuntu-latest

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -115,13 +115,33 @@ target "complete-cuda" {
     depends_on = ["core-cuda"]
 }
 
+target "mcp" {
+    context = "services/mcp"
+    dockerfile = "dockerfile.comfy.mcp"
+    platforms = PLATFORMS
+    tags = [
+        "${REGISTRY_URL}mcp:${IMAGE_LABEL}",
+        "${REGISTRY_URL}mcp:cache",
+        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}mcp:latest" : ""
+    ]
+    cache-from = ["type=registry,ref=${REGISTRY_URL}mcp:cache,optional=true"]
+    cache-to   = ["type=inline"]
+    args = {
+        MCP_VERSION = "v1.1.1"
+    }
+}
+
+group "mcp" {
+    targets = ["mcp"]
+}
+
 // Convenience groups
 group "default" {
     targets = ["all"]
 }
 
 group "all" {
-    targets = ["runtime", "cuda", "cpu"]
+    targets = ["runtime", "cuda", "cpu", "mcp"]
 }
 
 group "core" {
@@ -139,4 +159,3 @@ group "cuda" {
 group "cpu" {
     targets = ["runtime-cpu", "core-cpu"]
 }
-

--- a/services/mcp/dockerfile.comfy.mcp
+++ b/services/mcp/dockerfile.comfy.mcp
@@ -1,0 +1,47 @@
+# MCP server for ComfyUI — joenorton/comfyui-mcp-server
+# Standalone Python image; does NOT depend on the ComfyUI runtime image.
+# Communicates with ComfyUI over HTTP (COMFYUI_URL env var).
+#
+# Published as: ghcr.io/pixeloven/comfyui/mcp:<IMAGE_LABEL>
+
+ARG MCP_VERSION=v1.1.1
+
+FROM python:3.12-slim
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+ARG APP_UID=1000
+ARG APP_GID=1000
+RUN groupadd -g "$APP_GID" comfy && \
+    useradd -u "$APP_UID" -g "$APP_GID" -d /app -s /bin/bash -M comfy && \
+    mkdir -p /app
+
+WORKDIR /app
+
+# Fetch pinned upstream source
+ARG MCP_VERSION
+RUN git clone --depth 1 --branch "$MCP_VERSION" \
+      https://github.com/joenorton/comfyui-mcp-server.git . && \
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -rf .git
+
+# Upstream FastMCP() defaults host="127.0.0.1" via its __init__ kwarg default,
+# which explicit-kwarg initialization makes impossible to override via env var.
+# Patch the constructor call directly so the server binds all interfaces.
+RUN sed -i 's/port=9000,/port=9000, host="0.0.0.0",/' server.py
+
+RUN chown -R comfy:comfy /app
+
+USER comfy
+
+# COMFYUI_URL is required at runtime — point to the ComfyUI service
+ENV COMFYUI_URL=http://localhost:8188
+
+EXPOSE 9000
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
## Summary

Adds a standalone Docker image for [`joenorton/comfyui-mcp-server`](https://github.com/joenorton/comfyui-mcp-server) — an HTTP MCP server that bridges AI agents to ComfyUI via the [Model Context Protocol](https://modelcontextprotocol.io/).

### What's included

- **`services/mcp/dockerfile.comfy.mcp`** — standalone Python 3.12 image (not runtime-based); clones `comfyui-mcp-server@v1.1.1` and patches the FastMCP constructor to bind `0.0.0.0` (required for container networking — upstream defaults to `127.0.0.1`)
- **`docker-bake.hcl`** — new `mcp` target + `mcp` group; added to the `all` group
- **`.github/workflows/ci.yml`** — `test-bake-targets` validates the `mcp` target

### Image details

| Property | Value |
|----------|-------|
| Base | `python:3.12-slim` |
| Upstream | `joenorton/comfyui-mcp-server@v1.1.1` (Apache-2.0) |
| Port | 9000 |
| Transport | Streamable HTTP (`/mcp`) |
| Published as | `ghcr.io/pixeloven/comfyui/mcp:latest` |

### Usage

```yaml
# Kubernetes deployment env
- name: COMFYUI_URL
  value: "http://comfyui.comfyui.svc.cluster.local:8188"
```

```bash
# Local test
docker run --rm -p 9000:9000 -e COMFYUI_URL=http://host.docker.internal:8188 \
  ghcr.io/pixeloven/comfyui/mcp:latest
```

### Source patch note

The upstream `server.py` calls `FastMCP("...", port=9000)` which defaults `host="127.0.0.1"`. FastMCP passes this as an explicit kwarg to its pydantic-settings `Settings`, meaning the `FASTMCP_HOST` env var is ignored. A one-line `sed` patch changes `port=9000,` → `port=9000, host="0.0.0.0",` in the Dockerfile — zero Harmony application logic.

This was validated end-to-end in [ductiletoaster/harmony](https://github.com/ductiletoaster/harmony) before creating this PR (deployed to Kubernetes, confirmed `Uvicorn running on http://0.0.0.0:9000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)