### PR TITLE
fix(complete): pre-install Impact/Subpack/Inspire deps to avoid load race

### DIFF
--- a/services/comfy/complete/extra-requirements.txt
+++ b/services/comfy/complete/extra-requirements.txt
@@ -14,9 +14,14 @@ matplotlib>=3.10
 facexlib>=0.3
 insightface>=0.7
 
-# ComfyUI Impact Pack dependencies
+# ComfyUI Impact Pack + Subpack dependencies
 piexif>=1.1
 ultralytics>=8.3
+segment-anything>=1.0
+dill>=0.3
+
+# ComfyUI Inspire Pack dependencies
+webcolors>=24.0
 
 # RMBG and AILab Segmentation
 timm>=1.0


### PR DESCRIPTION
## Summary

Bakes `segment-anything`, `dill`, and `webcolors` into the `complete` image so that ComfyUI-Impact-Pack, ComfyUI-Impact-Subpack, and ComfyUI-Inspire-Pack load successfully on a fresh container start.

## Why

ComfyUI loads custom nodes synchronously during startup. ComfyUI-Manager installs missing pip dependencies *after* nodes are loaded. On every fresh pod boot in a K8s environment where `/app/.venv` is part of the container image (not on a PVC), this ordering produces a hard race:

```
### Loading: ComfyUI-Impact-Subpack (V1.3.5)
ModuleNotFoundError: No module named 'dill'

### Loading: ComfyUI-Impact-Pack (V8.28.3)
ModuleNotFoundError: No module named 'segment_anything'

### Loading: ComfyUI-Inspire-Pack (V1.23)
ModuleNotFoundError: No module named 'webcolors'
```

Manager installs each pkg successfully a few seconds later and prints `After restarting ComfyUI, please refresh the browser.`, but the pod is already `Ready` and K8s never restarts it — so the nodes stay missing until manual intervention. Confirmed in a live cluster: after Manager finished, `import segment_anything` worked from a shell inside the pod; the dep files were present in `/app/.venv/lib/python3.12/site-packages/`. Only the load order is wrong.

## Change

Three new lines under the existing pack-deps sections in `services/comfy/complete/extra-requirements.txt`:

```
# ComfyUI Impact Pack + Subpack dependencies
piexif>=1.1
ultralytics>=8.3
segment-anything>=1.0      # NEW — Impact Pack SAM integration
dill>=0.3                  # NEW — Impact Subpack ultralytics-detector serialization

# ComfyUI Inspire Pack dependencies
webcolors>=24.0            # NEW — Inspire Pack regional_nodes
```

`ultralytics>=8.3` was already baked in; this just completes the set.

## Test plan

- [ ] CI builds the `complete-cuda` target without resolver errors
- [ ] In-cluster: pull the new image SHA, update harmony's `infrastructure/kubernetes/apps/comfyui/deployment.yaml`, ArgoCD sync
- [ ] On fresh pod boot, the three packs load without `ModuleNotFoundError` (check via `kubectl logs -n comfyui $(kubectl get pods -n comfyui -l app.kubernetes.io/name=comfyui -o name) | grep -E '(Impact|Inspire)'`)
- [ ] ComfyUI-Manager still re-validates them on startup but each install is a no-op (deps already present)

## Out of scope

- `peft` was also seen being installed by Manager (visible in startup logs from harmony cluster) — not added here since it's not in the three packs the user flagged. Worth a follow-up survey of every custom-node dep that Manager currently installs on each boot.
- `sam2` (the Meta SAM2 git repo, separate from segment-anything/SAM1) — Manager pulls it from git on each boot. Baking a git-pinned `sam2` would need a `pip install git+https://...@<sha>` line; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)