### PR TITLE
feat(complete): bake remaining Manager-installed deps + SAM2 pin

### DIFF
--- a/services/comfy/complete/extra-requirements.txt
+++ b/services/comfy/complete/extra-requirements.txt
@@ -4,11 +4,20 @@
 accelerate>=1.10
 onnxruntime-gpu>=1.22
 diffusers>=0.34
+huggingface-hub>=0.19
+transformers>=4.30
+peft
+typing_extensions
 
 # Custom node optimizations - frequently used dependencies baked in for faster startup
 opencv-python-headless>=4.12
 scipy>=1.16
 matplotlib>=3.10
+spandrel
+sentencepiece
+lark
+ftfy
+protobuf>=3.20.2,<6.0.0
 
 # PuLID / IPAdapter
 facexlib>=0.3
@@ -19,6 +28,9 @@ piexif>=1.1
 ultralytics>=8.3
 segment-anything>=1.0
 dill>=0.3
+# SAM2 from facebookresearch — pinned to the commit Manager installed in
+# production (2026-05-26). Unpin only after testing a newer revision.
+git+https://github.com/facebookresearch/sam2@2b90b9f5ceec907a1c18123530e92e794ad901a4
 
 # ComfyUI Inspire Pack dependencies
 webcolors>=24.0


### PR DESCRIPTION
## Summary

Follow-up to #44. Audit of `ComfyUI-Manager` activity on every pod boot in production showed ~14 packages it reinstalls on each cold start. This bakes the heavy/frequent ones into the `complete` image and pins SAM2 from facebookresearch git so Manager has nothing left to reinstall for the audited workload.

## Audit method

On a fresh K8s pod, captured every `## ComfyUI-Manager: EXECUTE => [..., 'uv', 'pip', 'install', '<pkg>']` line plus every `Installed: + <pkg>==<ver>` line from boot logs, deduped, cross-referenced against the current `extra-requirements.txt`. Three categories:

- **Already baked** — no action needed: `accelerate`, `diffusers`, `onnxruntime-gpu`, `opencv-python-headless`, `matplotlib`, `piexif`, `ultralytics`, `groundingdino-py`, `timm`, plus the three from #44 (`segment-anything`, `dill`, `webcolors`)
- **In this PR** — see Change section below
- **Skipped** — `transparent-background`, `opencv-python` (non-headless conflicts with `-headless`), `onnxruntime` CPU variant, and the `hydra-core`/`omegaconf`/`iopath`/`decord` chain. These are either lower-frequency or only relevant to specific custom nodes outside the audited workload. Easy to add later if needed.

## Change

Diff against `services/comfy/complete/extra-requirements.txt`:

```diff
 # Additional dependencies
 accelerate>=1.10
 onnxruntime-gpu>=1.22
 diffusers>=0.34
+huggingface-hub>=0.19
+transformers>=4.30
+peft
+typing_extensions

 # Custom node optimizations …
 opencv-python-headless>=4.12
 scipy>=1.16
 matplotlib>=3.10
+spandrel
+sentencepiece
+lark
+ftfy
+protobuf>=3.20.2,<6.0.0

 # ComfyUI Impact Pack + Subpack dependencies
 piexif>=1.1
 ultralytics>=8.3
 segment-anything>=1.0
 dill>=0.3
+# SAM2 from facebookresearch — pinned to the commit Manager installed in
+# production (2026-05-26). Unpin only after testing a newer revision.
+git+https://github.com/facebookresearch/sam2@2b90b9f5ceec907a1c18123530e92e794ad901a4
```

| Group | Package | Why |
|---|---|---|
| Top group | `huggingface-hub>=0.19` | Impact / Inspire / RMBG model downloads |
| Top group | `transformers>=4.30` | Impact CLIP-related nodes + transitively many |
| Top group | `peft` | LoRA-using workflows |
| Top group | `typing_extensions` | Ubiquitous; reinstalled every boot |
| Optimizations | `spandrel` | ComfyUI upscaler runtime |
| Optimizations | `sentencepiece` | Transformers tokenizers |
| Optimizations | `lark` | Impact Pack wildcards engine |
| Optimizations | `ftfy` | CLIP text cleanup |
| Optimizations | `protobuf>=3.20.2,<6.0.0` | Tight pin (onnx / transformers compat) — matches Manager's spec |
| Impact Pack | SAM2 git pin | SAM2 functionality was reported "unavailable" in the pod. Pinning to `2b90b9f5ceec907a1c18123530e92e794ad901a4` — the exact commit Manager pulled yesterday — keeps the build reproducible. |

## Test plan

- [ ] CI builds `complete-cuda` cleanly (no resolver conflicts between `transformers`, `protobuf` pin, `peft`)
- [ ] SAM2 git clone succeeds during build (it's a sizeable pull)
- [ ] After harmony cluster picks up the new image SHA, boot logs show **zero** `## ComfyUI-Manager: EXECUTE => [..., 'install', ...]` lines for the listed packages
- [ ] `[Impact Pack] The SAM2 functionality is unavailable` message disappears
- [ ] Cold-boot time noticeably shorter (current first-boot Manager activation ~3–5 min downloading wheels)

## Stacked on

- #44 (merged) — added `segment-anything`, `dill`, `webcolors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)