### PR TITLE
fix(core): use --index-url for torch family + parameterise via TORCH_INDEX arg

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -67,6 +67,7 @@ target "core-cuda" {
     cache-to   = ["type=inline"]
     args = {
         RUNTIME = "cuda"
+        TORCH_INDEX = "cu128"
     }
     depends_on = ["runtime-cuda"]
 }
@@ -90,6 +91,7 @@ target "core-cpu" {
     cache-to   = ["type=inline"]
     args = {
         RUNTIME = "cpu"
+        TORCH_INDEX = "cpu"
     }
     depends_on = ["runtime-cpu"]
 }

--- a/services/comfy/core/dockerfile.comfy.core
+++ b/services/comfy/core/dockerfile.comfy.core
@@ -21,11 +21,29 @@ RUN umask 022 && \
 # We clone into a temporary directory and move to /app/ComfyUI to prevent
 # permission issues if we were to mount /app entirely in dev modes
 ARG RUNTIME=cuda
+
+# CUDA wheel index for the torch family (torch / torchaudio / torchvision).
+# Defaults to cu128 for the cuda target; the cpu target overrides this to
+# "cpu" via docker-bake.hcl. Future cuda variants (cu130, etc.) can be
+# added by introducing a new bake target with `args = { TORCH_INDEX = "cu130" }`.
+ARG TORCH_INDEX=cu128
+
 RUN --mount=type=cache,target=/app/.cache/pip \
   umask 022 && \
   git clone https://github.com/comfyanonymous/ComfyUI.git /app/ComfyUI && \
-  pip install --extra-index-url https://download.pytorch.org/whl/cu128 \
-    -r /app/ComfyUI/requirements.txt && \
+  # Install torch family from the wheel index ONLY (not --extra-index-url).
+  # --extra-index-url is additive, so pip picks the highest version across
+  # PyPI + the index. When PyPI ships a newer torch than the cu* index
+  # (which happens regularly), pip picks the PyPI build, leaving torch and
+  # torchaudio compiled against different CUDA versions. Using --index-url
+  # replaces PyPI for this command, so resolution is constrained to the
+  # specified index and the CUDA ABI stays consistent across all three.
+  pip install --index-url https://download.pytorch.org/whl/${TORCH_INDEX} \
+    torch torchaudio torchvision && \
+  # Install the rest of ComfyUI's requirements normally. torch, torchaudio,
+  # and torchvision are already installed; pip will see them satisfied and
+  # skip re-resolution.
+  pip install -r /app/ComfyUI/requirements.txt && \
   pip install -r /app/ComfyUI/manager_requirements.txt
 
 # ==================================================================


### PR DESCRIPTION
## Summary

ComfyUI's `requirements.txt` has bare `torch / torchaudio / torchvision` lines (no version pins, no wheel URLs). The core Dockerfile installed those with `--extra-index-url https://download.pytorch.org/whl/cu128` — but that flag is **additive**. Pip picks the highest version found across **PyPI + the extra index**.

When PyPI ships a newer torch than the cu128 index (which happens regularly), pip splits the resolution:

| Package | PyPI has | cu128 index has | Pip picks |
|---|---|---|---|
| `torch` | `2.12.0` (cu130 ABI) | `2.11.0+cu128` | **`2.12.0` (PyPI)** — newer wins |
| `torchaudio` | (none matching) | `2.11.0+cu128` | **`2.11.0+cu128`** |
| `torchvision` | `0.27.0` (cu130 ABI) | older | **`0.27.0` (PyPI)** |

Result: torch / torchvision compiled against cu130 + torchaudio compiled against cu128 → runtime crash on first `import torchaudio`:

```
RuntimeError: Detected that PyTorch and TorchAudio were compiled with
different CUDA versions. PyTorch has CUDA version 13.0 whereas
TorchAudio has CUDA version 12.8.
```

The current published `complete:cuda-latest` image happens to work because it was built when PyPI didn't yet have `torch 2.12.0` — pure timing luck. The next clean Weekly Fresh Rebuild would have failed regardless of any extras changes.

## How I confirmed

Built `complete-cuda` locally from `main` (no PRs in flight). Resulting image errors on `python -c "import torchaudio"` with the exact crash above. Inspecting the build log shows the core layer downloading `torch-2.12.0` from PyPI (no `+cu128` suffix) and `torchaudio-2.11.0+cu128` from the cu128 index.

## Fix

Two-stage install in core:

1. `pip install --index-url https://download.pytorch.org/whl/${TORCH_INDEX} torch torchaudio torchvision` — `--index-url` **replaces** PyPI for this command, so all three are pulled from the same wheel index with a consistent CUDA ABI.
2. `pip install -r /app/ComfyUI/requirements.txt` runs normally afterwards — torch family already satisfied, pip skips re-resolution.

Wired through `ARG TORCH_INDEX=cu128` and parameterised in `docker-bake.hcl`:

- `core-cuda` → `TORCH_INDEX=cu128`
- `core-cpu`  → `TORCH_INDEX=cpu`

Adding a cu130 variant becomes a single bake-target addition (`args = { TORCH_INDEX = "cu130" }`), no Dockerfile changes.

## Local verification

Building locally with the fix now to confirm consistent CUDA versions across the torch family. Will comment with the result before requesting merge.

## Supersedes

[#46](https://github.com/pixeloven/ComfyUI-Docker/pull/46) (closed). That one tried to fix it in `complete` with `--extra-index-url cu130`, which (a) targeted the wrong layer, (b) wouldn't fix the index-priority bug, and (c) would have unnecessarily moved the image to cu130.

## Test plan

- [ ] Local `docker buildx bake core-cuda complete-cuda` produces consistent cu128 wheels for torch / torchaudio / torchvision (in-flight)
- [ ] `docker run --rm <built-image> /app/.venv/bin/python -c "import torchaudio; print(torchaudio.__version__)"` succeeds without CUDA-mismatch error
- [ ] CI rebuild passes
- [ ] In-cluster pod boots cleanly when harmony bumps to the new image SHA
- [ ] `core-cpu` build still works (TORCH_INDEX=cpu — separate validation since prod uses cuda)

🤖 Generated with [Claude Code](https://claude.com/claude-code)