### PR TITLE
Modernize ComfyUI releases and accelerator support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   validate-examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Validate Example Configurations
       run: |
@@ -33,7 +33,7 @@ jobs:
   test-bake-targets:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Test Docker Bake targets
       run: |
@@ -53,7 +53,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
@@ -73,12 +73,12 @@ jobs:
         echo "✅ Docker system cleaned"
         
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         buildkitd-flags: --debug
   
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -105,7 +105,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build CUDA images
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v7
       with:
         files: docker-bake.hcl
         targets: cuda
@@ -129,7 +129,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
@@ -149,12 +149,12 @@ jobs:
         echo "✅ Docker system cleaned"
         
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         buildkitd-flags: --debug
   
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -172,7 +172,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build CPU images
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v7
       with:
         files: docker-bake.hcl
         targets: cpu
@@ -200,7 +200,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
@@ -214,10 +214,10 @@ jobs:
         swap-storage: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -233,7 +233,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build ${{ matrix.target }} images
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v7
       with:
         files: docker-bake.hcl
         targets: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     
     - name: Validate Example Configurations
       run: |
-        for example in core-cpu core-gpu complete-gpu; do
+        for example in core-cpu core-gpu complete-gpu core-amd core-intel; do
           echo "Validating examples/$example..."
           cd examples/$example
           # Create temporary .env for validation
@@ -43,6 +43,8 @@ jobs:
         docker buildx bake --file docker-bake.hcl --print | grep -q "runtime-cpu"
         docker buildx bake --file docker-bake.hcl --print | grep -q "runtime-cuda"
         docker buildx bake --file docker-bake.hcl --print | grep -q "complete-cuda"
+        docker buildx bake --file docker-bake.hcl --print | grep -q "core-rocm"
+        docker buildx bake --file docker-bake.hcl --print | grep -q "core-xpu"
         docker buildx bake --file docker-bake.hcl --print | grep -q "mcp"
 
   build-cuda:
@@ -98,6 +100,9 @@ jobs:
         echo "commit_ref=${GITHUB_SHA}" >> $GITHUB_OUTPUT
         echo "branch=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
         echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+        echo "comfyui_version=$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Build CUDA images
       uses: docker/bake-action@v5
@@ -115,6 +120,8 @@ jobs:
       env:
         REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
         IMAGE_LABEL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.meta.outputs.commit_sha || 'latest' }}
+        COMFYUI_VERSION: ${{ steps.meta.outputs.comfyui_version }}
+        PUBLISH_LATEST: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   build-cpu:
     runs-on: ubuntu-latest
@@ -160,6 +167,9 @@ jobs:
         echo "commit_ref=${GITHUB_SHA}" >> $GITHUB_OUTPUT
         echo "branch=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
         echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+        echo "comfyui_version=$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Build CPU images
       uses: docker/bake-action@v5
@@ -177,3 +187,66 @@ jobs:
       env:
         REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
         IMAGE_LABEL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.meta.outputs.commit_sha || 'latest' }}
+        COMFYUI_VERSION: ${{ steps.meta.outputs.comfyui_version }}
+        PUBLISH_LATEST: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+  build-linux-accelerators:
+    runs-on: ubuntu-latest
+    needs: [validate-examples, test-bake-targets]
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [rocm, xpu]
+    env:
+      REGISTRY: ghcr.io
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      run: |
+        echo "commit_sha=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+        echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+        echo "comfyui_version=$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Build ${{ matrix.target }} images
+      uses: docker/bake-action@v5
+      with:
+        files: docker-bake.hcl
+        targets: ${{ matrix.target }}
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        set: |
+          *.cache-from=type=gha,scope=${{ matrix.target }}
+          *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}
+        provenance: false
+        sbom: false
+      env:
+        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
+        IMAGE_LABEL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.meta.outputs.commit_sha || 'latest' }}
+        COMFYUI_VERSION: ${{ steps.meta.outputs.comfyui_version }}
+        PUBLISH_LATEST: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -56,6 +56,9 @@ jobs:
       id: meta
       run: |
         echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+        echo "comfyui_version=$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Build CUDA images without cache
       uses: docker/bake-action@v5
@@ -64,13 +67,15 @@ jobs:
         targets: cuda
         push: true
         no-cache: true
-      env:
-        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
         github-token: ${{ secrets.GITHUB_TOKEN }}
         set: |
           *.cache-to=type=gha,mode=max
         provenance: false
         sbom: false
+      env:
+        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
+        COMFYUI_VERSION: ${{ steps.meta.outputs.comfyui_version }}
+        PUBLISH_LATEST: true
 
   rebuild-cpu:
     runs-on: ubuntu-latest
@@ -112,6 +117,9 @@ jobs:
       id: meta
       run: |
         echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+        echo "comfyui_version=$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Build CPU images without cache
       uses: docker/bake-action@v5
@@ -120,17 +128,76 @@ jobs:
         targets: cpu
         push: true
         no-cache: true
-      env:
-        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
         github-token: ${{ secrets.GITHUB_TOKEN }}
         set: |
           *.cache-to=type=gha,mode=max
         provenance: false
         sbom: false
+      env:
+        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
+        COMFYUI_VERSION: ${{ steps.meta.outputs.comfyui_version }}
+        PUBLISH_LATEST: true
+
+  rebuild-linux-accelerators:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [rocm, xpu]
+    env:
+      REGISTRY: ghcr.io
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      run: |
+        echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+        echo "comfyui_version=$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Build ${{ matrix.target }} images without cache
+      uses: docker/bake-action@v5
+      with:
+        files: docker-bake.hcl
+        targets: ${{ matrix.target }}
+        push: true
+        no-cache: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        set: |
+          *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}
+        provenance: false
+        sbom: false
+      env:
+        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
+        COMFYUI_VERSION: ${{ steps.meta.outputs.comfyui_version }}
+        PUBLISH_LATEST: true
 
   rebuild-summary:
     if: always()
-    needs: [rebuild-cuda, rebuild-cpu]
+    needs: [rebuild-cuda, rebuild-cpu, rebuild-linux-accelerators]
     runs-on: ubuntu-latest
     steps:
     - name: Rebuild Summary

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
@@ -41,12 +41,12 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         buildkitd-flags: --debug
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build CUDA images without cache
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v7
       with:
         files: docker-bake.hcl
         targets: cuda
@@ -82,7 +82,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
@@ -102,12 +102,12 @@ jobs:
         echo "✅ Docker system cleaned"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         buildkitd-flags: --debug
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -122,7 +122,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build CPU images without cache
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v7
       with:
         files: docker-bake.hcl
         targets: cpu
@@ -147,7 +147,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
@@ -161,10 +161,10 @@ jobs:
         swap-storage: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -179,7 +179,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build ${{ matrix.target }} images without cache
-      uses: docker/bake-action@v5
+      uses: docker/bake-action@v7
       with:
         files: docker-bake.hcl
         targets: ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ComfyUI-Docker Makefile
 # Provides convenient targets for local development and building
 
-.PHONY: help all runtime core cuda cpu clean
+.PHONY: help all runtime core cuda cpu rocm xpu clean
 
 # Default target
 help: ## Show this help message
@@ -41,6 +41,12 @@ cuda: ## Build complete CUDA stack and load to Docker
 cpu: ## Build complete CPU stack and load to Docker
 	docker buildx bake cpu --load
 
+rocm: ## Build AMD ROCm stack and load to Docker
+	docker buildx bake rocm --load
+
+xpu: ## Build Intel XPU stack and load to Docker
+	docker buildx bake xpu --load
+
 # Complete images
 complete-cuda: ## Build CUDA complete image and load to Docker
 	docker buildx bake complete-cuda --load
@@ -58,6 +64,8 @@ validate: ## Validate Bake and example Compose configurations
 	cd examples/core-gpu && docker compose config --quiet
 	cd examples/complete-gpu && docker compose config --quiet
 	cd examples/core-cpu && docker compose config --quiet
+	cd examples/core-amd && docker compose config --quiet
+	cd examples/core-intel && docker compose config --quiet
 
 push: ## Build and push all images to registry (don't load locally)
 	docker buildx bake all --push
@@ -72,10 +80,18 @@ test-cpu: ## Start core-cpu example locally for testing
 test-complete: ## Start complete-gpu example locally for testing
 	cd examples/complete-gpu && docker compose up -d
 
+test-amd: ## Start the AMD ROCm example locally for testing
+	cd examples/core-amd && docker compose up -d
+
+test-intel: ## Start the Intel XPU example locally for testing
+	cd examples/core-intel && docker compose up -d
+
 stop: ## Stop all example services
 	-cd examples/core-gpu && docker compose down
 	-cd examples/complete-gpu && docker compose down
 	-cd examples/core-cpu && docker compose down
+	-cd examples/core-amd && docker compose down
+	-cd examples/core-intel && docker compose down
 
 logs: ## Show logs from core-gpu example
 	cd examples/core-gpu && docker compose logs -f

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/pixeloven?style=for-the-badge&logo=github&label=Sponsor)](https://github.com/sponsors/pixeloven)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?style=for-the-badge&logo=buymeacoffee)](https://buymeacoffee.com/pixeloven)
 
-**Production-ready Docker setup for [ComfyUI](https://github.com/comfyanonymous/ComfyUI)**
+**Production-ready Docker setup for [ComfyUI](https://github.com/Comfy-Org/ComfyUI)**
 
 A complete containerized deployment of ComfyUI with GPU acceleration, flexible deployment profiles, and persistent data management. Built with Docker Buildx Bake for efficient multi-stage builds.
 
@@ -23,11 +23,11 @@ A complete containerized deployment of ComfyUI with GPU acceleration, flexible d
 
 ## Key Features
 
-- **🚀 GPU-Accelerated**: NVIDIA CUDA 12.9 support with optimized runtime
-- **🎯 Multiple Profiles**: Core (minimal), Complete (full-featured), CPU-only
+- **🚀 Current Accelerators**: NVIDIA CUDA 13.0, AMD ROCm 7.2, Intel XPU, and CPU
+- **🎯 Versioned ComfyUI**: Stable release tags by default, explicit nightly builds when wanted
 - **📁 Persistent Storage**: Individual volume mounts for models, outputs, custom nodes, etc.
 - **🐳 Production Ready**: Multi-stage builds, layer caching, and pre-built GHCR images
-- **⚡ Performance Optimized**: SageAttention for 2-3x faster attention computation
+- **⚡ Performance Optimized**: Dynamic VRAM, async offload, CUDA graphs, and Comfy Kitchen attention support
 - **🔧 Extensible**: Custom node support via volume mounts
 - **🔄 CI/CD Ready**: Automated builds, weekly dependency updates
 - **🔒 Security**: Runs as non-root by default, supports Docker Compose PUID/PGID and Kubernetes securityContext
@@ -60,7 +60,7 @@ cd examples/core-gpu
 docker compose up -d
 ```
 
-**Complete GPU** (optimized dependencies + SageAttention):
+**Complete GPU** (extra custom-node dependencies):
 ```bash
 cd examples/complete-gpu
 docker compose up -d
@@ -84,12 +84,14 @@ Place your Stable Diffusion checkpoints in `./data/models/checkpoints/` or downl
 
 ## Deployment Profiles
 
-ComfyUI Docker offers three deployment profiles to match your use case:
+ComfyUI Docker offers five deployment examples to match your hardware and use case:
 
 | Example | Container | Image | Best For | Features |
 |---------|-----------|-------|----------|----------|
 | **`core-gpu`** | `comfyui-core-gpu` | `ghcr.io/pixeloven/comfyui/core:cuda-latest` | Most users | Essential ComfyUI + GPU acceleration |
-| **`complete-gpu`** | `comfyui-complete-gpu` | `ghcr.io/pixeloven/comfyui/complete:cuda-latest` | Power users | Pre-installed Python deps + SageAttention optimization |
+| **`complete-gpu`** | `comfyui-complete-gpu` | `ghcr.io/pixeloven/comfyui/complete:cuda-latest` | Power users | Pre-installed common custom-node dependencies |
+| **`core-amd`** | `comfyui-core-amd` | `ghcr.io/pixeloven/comfyui/core:rocm-latest` | AMD Linux | PyTorch ROCm 7.2 |
+| **`core-intel`** | `comfyui-core-intel` | `ghcr.io/pixeloven/comfyui/core:xpu-latest` | Intel Arc Linux | PyTorch XPU |
 | **`core-cpu`** | `comfyui-core-cpu` | `ghcr.io/pixeloven/comfyui/core:cpu-latest` | Testing/Compatibility | No GPU required |
 
 ### Core GPU (`examples/core-gpu`) ⚡
@@ -102,13 +104,13 @@ docker compose up -d
 ```
 
 - ✅ Essential ComfyUI functionality
-- ✅ GPU acceleration (CUDA 12.9)
+- ✅ GPU acceleration (CUDA 13.0 / PyTorch cu130)
 - ✅ Fast startup
 - ✅ Smaller image size
 
 ### Complete GPU (`examples/complete-gpu`) 🚀
 
-Optimized deployment with pre-installed Python dependencies and SageAttention.
+CUDA deployment with pre-installed Python dependencies used by common custom nodes.
 
 ```bash
 cd examples/complete-gpu
@@ -116,7 +118,7 @@ docker compose up -d
 ```
 - ✅ Everything core has
 - ✅ Pre-installed Python dependencies for common custom node setups
-- ✅ SageAttention 2.2.0 + SageAttn3 3.0.0 optimization (2-3x faster)
+- ✅ Current Comfy Kitchen attention backend available with `CLI_ARGS=--use-ck-attention`
 - ⚠️  Larger image size
 
 ### Core CPU (`examples/core-cpu`)
@@ -142,6 +144,7 @@ ComfyUI Docker uses **individual volume mounts** for each data directory, provid
 ./data/
 ├── models/          → /app/models          (AI models, checkpoints, LoRAs)
 ├── custom_nodes/    → /app/custom_nodes    (Extensions and plugins)
+├── datasets/        → /app/datasets        (LoRA training datasets)
 ├── input/           → /app/input           (Input images/workflows)
 ├── output/          → /app/output          (Generated outputs)
 ├── temp/            → /app/temp            (Temporary files)
@@ -195,7 +198,7 @@ securityContext:
   fsGroup: 3000
 ```
 
-The Python virtual environment's `site-packages` directory is world-writable at build time, so ComfyUI Manager can install custom node dependencies regardless of the runtime UID.
+The Python virtual environment's package and entry-point directories are world-writable at build time, so ComfyUI Manager can install custom node dependencies regardless of the runtime UID.
 
 **For complete configuration options, see:**
 - [Running Containers Guide](docs/user-guides/running.md) - Environment variables, Docker Compose, and Kubernetes
@@ -282,7 +285,7 @@ docker compose logs -f
 ### Contribution Guidelines
 
 - Follow existing code style and structure
-- Test your changes with all three profiles
+- Test your changes with all five examples
 - Update documentation for new features
 - Add meaningful commit messages
 - Ensure CI/CD checks pass
@@ -293,11 +296,11 @@ docker compose logs -f
 
 ### What is ComfyUI Docker?
 
-ComfyUI Docker is a production-ready containerization of **[ComfyUI](https://github.com/comfyanonymous/ComfyUI)**, a powerful node-based interface for Stable Diffusion and other AI image generation models. This project provides:
+ComfyUI Docker is a production-ready containerization of **[ComfyUI](https://github.com/Comfy-Org/ComfyUI)**, a node-based engine for image, video, audio, 3D, and language workflows. This project provides:
 
 - **Multiple deployment profiles** (core, complete, CPU-only)
 - **Multi-stage Docker builds** using Docker Buildx Bake
-- **GPU acceleration** with NVIDIA CUDA support
+- **GPU acceleration** for NVIDIA CUDA, AMD ROCm, and Intel XPU on Linux
 - **Persistent data management** with granular volume mounting
 - **Pre-built images** available on GitHub Container Registry
 - **Flexible configuration** via environment variables
@@ -307,12 +310,13 @@ Perfect for local development, production deployments, or CI/CD pipelines.
 ### Which profile should I use?
 
 - **Core Mode**: Best for most users - fast startup, essential features, GPU acceleration
-- **Complete Mode**: Best for power users - pre-installed Python dependencies for common custom nodes, SageAttention optimization
+- **Complete Mode**: Best for NVIDIA power users who want common custom-node dependencies pre-installed
+- **AMD/Intel Modes**: Core images using the official PyTorch ROCm or XPU wheel channels
 - **CPU Mode**: Best for testing or when no GPU is available
 
 ### Do I need a GPU?
 
-For **Core** and **Complete** modes, yes - an NVIDIA GPU with CUDA support is required. For **CPU mode**, no GPU is needed, but image generation will be significantly slower.
+The CUDA and Complete examples require NVIDIA, the AMD example requires a ROCm-supported GPU, and the Intel example requires a supported Intel GPU. CPU mode needs no GPU but is significantly slower.
 
 ### Where are my models and outputs stored?
 
@@ -341,7 +345,7 @@ docker buildx bake all --no-cache
 
 ### Why is my container slow to start?
 
-**Complete mode** has a larger image due to pre-installed Python dependencies and SageAttention. If startup time is a concern and you don't need the extra optimizations, consider using **Core mode**.
+**Complete mode** has a larger image due to pre-installed Python dependencies. Use **Core mode** when custom nodes can manage their own dependencies.
 
 ---
 
@@ -349,7 +353,7 @@ docker buildx bake all --no-cache
 
 This project is licensed under the **[MIT License](LICENSE)**.
 
-**ComfyUI** itself is licensed under **GPL-3.0** - see the [ComfyUI repository](https://github.com/comfyanonymous/ComfyUI/blob/master/LICENSE) for details.
+**ComfyUI** itself is licensed under **GPL-3.0** - see the [ComfyUI repository](https://github.com/Comfy-Org/ComfyUI/blob/master/LICENSE) for details.
 
 ---
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,6 +22,19 @@ variable "PLATFORMS" {
     default = ["linux/amd64"]
 }
 
+variable "COMFYUI_VERSION" {
+    // Repository builds pin a stable upstream source tag by default. Scheduled
+    // publishing resolves the latest upstream release and overrides this.
+    // Set to "master" explicitly for a nightly build.
+    default = "v0.33.1"
+}
+
+variable "PUBLISH_LATEST" {
+    // CI sets this only for stable publishing. A nightly/custom IMAGE_LABEL
+    // must never move the stable *-latest tags.
+    default = false
+}
+
 target "runtime-cuda" {
     context = "services/runtime"
     dockerfile = "dockerfile.cuda.runtime"
@@ -29,7 +42,7 @@ target "runtime-cuda" {
     tags = [
         "${REGISTRY_URL}runtime:cuda-${IMAGE_LABEL}",
         "${REGISTRY_URL}runtime:cuda-cache",
-        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}runtime:cuda-latest" : ""
+        PUBLISH_LATEST ? "${REGISTRY_URL}runtime:cuda-latest" : ""
     ]
     cache-from = ["type=registry,ref=${REGISTRY_URL}runtime:cuda-cache,optional=true"]
     cache-to   = ["type=inline"]
@@ -42,9 +55,35 @@ target "runtime-cpu" {
     tags = [
         "${REGISTRY_URL}runtime:cpu-${IMAGE_LABEL}",
         "${REGISTRY_URL}runtime:cpu-cache",
-        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}runtime:cpu-latest" : ""
+        PUBLISH_LATEST ? "${REGISTRY_URL}runtime:cpu-latest" : ""
     ]
     cache-from = ["type=registry,ref=${REGISTRY_URL}runtime:cpu-cache,optional=true"]
+    cache-to   = ["type=inline"]
+}
+
+target "runtime-rocm" {
+    context = "services/runtime"
+    dockerfile = "dockerfile.cpu.runtime"
+    platforms = PLATFORMS
+    tags = [
+        "${REGISTRY_URL}runtime:rocm-${IMAGE_LABEL}",
+        "${REGISTRY_URL}runtime:rocm-cache",
+        PUBLISH_LATEST ? "${REGISTRY_URL}runtime:rocm-latest" : ""
+    ]
+    cache-from = ["type=registry,ref=${REGISTRY_URL}runtime:rocm-cache,optional=true"]
+    cache-to   = ["type=inline"]
+}
+
+target "runtime-xpu" {
+    context = "services/runtime"
+    dockerfile = "dockerfile.cpu.runtime"
+    platforms = PLATFORMS
+    tags = [
+        "${REGISTRY_URL}runtime:xpu-${IMAGE_LABEL}",
+        "${REGISTRY_URL}runtime:xpu-cache",
+        PUBLISH_LATEST ? "${REGISTRY_URL}runtime:xpu-latest" : ""
+    ]
+    cache-from = ["type=registry,ref=${REGISTRY_URL}runtime:xpu-cache,optional=true"]
     cache-to   = ["type=inline"]
 }
 
@@ -57,8 +96,9 @@ target "core-cuda" {
     platforms = PLATFORMS
     tags = [
         "${REGISTRY_URL}core:cuda-${IMAGE_LABEL}",
+        "${REGISTRY_URL}core:cuda-${COMFYUI_VERSION}",
         "${REGISTRY_URL}core:cuda-cache",
-        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}core:cuda-latest" : ""
+        PUBLISH_LATEST ? "${REGISTRY_URL}core:cuda-latest" : ""
     ]
     cache-from = [
         "type=registry,ref=${REGISTRY_URL}runtime:cuda-cache,optional=true",
@@ -67,7 +107,8 @@ target "core-cuda" {
     cache-to   = ["type=inline"]
     args = {
         RUNTIME = "cuda"
-        TORCH_INDEX = "cu128"
+        TORCH_INDEX = "cu130"
+        COMFYUI_VERSION = COMFYUI_VERSION
     }
     depends_on = ["runtime-cuda"]
 }
@@ -81,8 +122,9 @@ target "core-cpu" {
     platforms = PLATFORMS
     tags = [
         "${REGISTRY_URL}core:cpu-${IMAGE_LABEL}",
+        "${REGISTRY_URL}core:cpu-${COMFYUI_VERSION}",
         "${REGISTRY_URL}core:cpu-cache",
-        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}core:cpu-latest" : ""
+        PUBLISH_LATEST ? "${REGISTRY_URL}core:cpu-latest" : ""
     ]
     cache-from = [
         "type=registry,ref=${REGISTRY_URL}runtime:cpu-cache,optional=true",
@@ -92,8 +134,61 @@ target "core-cpu" {
     args = {
         RUNTIME = "cpu"
         TORCH_INDEX = "cpu"
+        COMFYUI_VERSION = COMFYUI_VERSION
     }
     depends_on = ["runtime-cpu"]
+}
+
+target "core-rocm" {
+    context = "services/comfy/core"
+    contexts = {
+        runtime = "target:runtime-rocm"
+    }
+    dockerfile = "dockerfile.comfy.core"
+    platforms = PLATFORMS
+    tags = [
+        "${REGISTRY_URL}core:rocm-${IMAGE_LABEL}",
+        "${REGISTRY_URL}core:rocm-${COMFYUI_VERSION}",
+        "${REGISTRY_URL}core:rocm-cache",
+        PUBLISH_LATEST ? "${REGISTRY_URL}core:rocm-latest" : ""
+    ]
+    cache-from = [
+        "type=registry,ref=${REGISTRY_URL}runtime:rocm-cache,optional=true",
+        "type=registry,ref=${REGISTRY_URL}core:rocm-cache,optional=true"
+    ]
+    cache-to = ["type=inline"]
+    args = {
+        RUNTIME = "rocm"
+        TORCH_INDEX = "rocm7.2"
+        COMFYUI_VERSION = COMFYUI_VERSION
+    }
+    depends_on = ["runtime-rocm"]
+}
+
+target "core-xpu" {
+    context = "services/comfy/core"
+    contexts = {
+        runtime = "target:runtime-xpu"
+    }
+    dockerfile = "dockerfile.comfy.core"
+    platforms = PLATFORMS
+    tags = [
+        "${REGISTRY_URL}core:xpu-${IMAGE_LABEL}",
+        "${REGISTRY_URL}core:xpu-${COMFYUI_VERSION}",
+        "${REGISTRY_URL}core:xpu-cache",
+        PUBLISH_LATEST ? "${REGISTRY_URL}core:xpu-latest" : ""
+    ]
+    cache-from = [
+        "type=registry,ref=${REGISTRY_URL}runtime:xpu-cache,optional=true",
+        "type=registry,ref=${REGISTRY_URL}core:xpu-cache,optional=true"
+    ]
+    cache-to = ["type=inline"]
+    args = {
+        RUNTIME = "xpu"
+        TORCH_INDEX = "xpu"
+        COMFYUI_VERSION = COMFYUI_VERSION
+    }
+    depends_on = ["runtime-xpu"]
 }
 
 target "complete-cuda" {
@@ -105,8 +200,9 @@ target "complete-cuda" {
     platforms = PLATFORMS
     tags = [
         "${REGISTRY_URL}complete:cuda-${IMAGE_LABEL}",
+        "${REGISTRY_URL}complete:cuda-${COMFYUI_VERSION}",
         "${REGISTRY_URL}complete:cuda-cache",
-        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}complete:cuda-latest" : ""
+        PUBLISH_LATEST ? "${REGISTRY_URL}complete:cuda-latest" : ""
     ]
     cache-from = [
         "type=registry,ref=${REGISTRY_URL}runtime:cuda-cache,optional=true",
@@ -124,7 +220,7 @@ target "mcp" {
     tags = [
         "${REGISTRY_URL}mcp:${IMAGE_LABEL}",
         "${REGISTRY_URL}mcp:cache",
-        notequal("",IMAGE_LABEL) && notequal("latest",IMAGE_LABEL) ? "${REGISTRY_URL}mcp:latest" : ""
+        PUBLISH_LATEST ? "${REGISTRY_URL}mcp:latest" : ""
     ]
     cache-from = ["type=registry,ref=${REGISTRY_URL}mcp:cache,optional=true"]
     cache-to   = ["type=inline"]
@@ -143,15 +239,15 @@ group "default" {
 }
 
 group "all" {
-    targets = ["runtime", "cuda", "cpu", "mcp"]
+    targets = ["runtime", "cuda", "cpu", "rocm", "xpu", "mcp"]
 }
 
 group "core" {
-    targets = ["runtime-cuda", "runtime-cpu", "core-cuda", "core-cpu"]
+    targets = ["runtime-cuda", "runtime-cpu", "runtime-rocm", "runtime-xpu", "core-cuda", "core-cpu", "core-rocm", "core-xpu"]
 }
 
 group "runtime" {
-    targets = ["runtime-cuda", "runtime-cpu"]
+    targets = ["runtime-cuda", "runtime-cpu", "runtime-rocm", "runtime-xpu"]
 }
 
 group "cuda" {
@@ -160,4 +256,12 @@ group "cuda" {
 
 group "cpu" {
     targets = ["runtime-cpu", "core-cpu"]
+}
+
+group "rocm" {
+    targets = ["runtime-rocm", "core-rocm"]
+}
+
+group "xpu" {
+    targets = ["runtime-xpu", "core-xpu"]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Essential guides for users:
 - **[Running Containers](user-guides/running.md)** - Docker Compose operations and `.env` configuration
 - **[Data Management](user-guides/data.md)** - Models, workflows, and persistent storage
 - **[Performance Tuning](user-guides/performance.md)** - CLI arguments and resource optimization
+- **[Current Feature Support](user-guides/features.md)** - Ecosystem audit and container support matrix
 
 **[View all User Guides →](user-guides/index.md)**
 

--- a/docs/user-guides/building.md
+++ b/docs/user-guides/building.md
@@ -11,8 +11,10 @@ Pre-built images are automatically published to GitHub Container Registry and us
 | Image | Tag | Description |
 |-------|-----|-------------|
 | `ghcr.io/pixeloven/comfyui/core` | `cuda-latest` | Essential ComfyUI with CUDA GPU support |
-| `ghcr.io/pixeloven/comfyui/complete` | `cuda-latest` | Full features with custom nodes |
+| `ghcr.io/pixeloven/comfyui/complete` | `cuda-latest` | Common custom-node dependencies pre-installed |
 | `ghcr.io/pixeloven/comfyui/core` | `cpu-latest` | CPU-only mode |
+| `ghcr.io/pixeloven/comfyui/core` | `rocm-latest` | AMD ROCm 7.2 |
+| `ghcr.io/pixeloven/comfyui/core` | `xpu-latest` | Intel XPU |
 
 ### Pull Latest Images
 
@@ -25,8 +27,8 @@ docker compose pull
 ### Image Updates
 
 Images are rebuilt automatically:
-- **Weekly**: Every Sunday at 2:00 AM UTC with latest dependencies
-- **On Release**: When new versions are tagged
+- **Weekly**: Every Sunday at 2:00 AM UTC, resolving the newest stable upstream release
+- **On project changes**: CI resolves the newest stable upstream release
 - **Manual**: Via GitHub Actions workflow
 
 ### Use Specific Version
@@ -34,8 +36,8 @@ Images are rebuilt automatically:
 Override the image version:
 
 ```bash
-# In .env file
-COMFY_IMAGE=ghcr.io/pixeloven/comfyui/core:cuda-dev
+# Mirror the upstream ComfyUI release tag
+COMFY_IMAGE=ghcr.io/pixeloven/comfyui/core:cuda-v0.33.1
 
 # Or inline
 COMFY_IMAGE=ghcr.io/pixeloven/comfyui/core:cuda-abc1234 docker compose up -d
@@ -54,6 +56,8 @@ docker buildx bake all --load
 # Build specific groups
 docker buildx bake cuda --load        # CUDA GPU images
 docker buildx bake cpu --load         # CPU-only images
+docker buildx bake rocm --load        # AMD ROCm images
+docker buildx bake xpu --load         # Intel XPU images
 docker buildx bake runtime --load     # Base runtime layers only
 docker buildx bake core --load        # Core ComfyUI images
 ```
@@ -64,6 +68,8 @@ docker buildx bake core --load        # Core ComfyUI images
 # Core images
 docker buildx bake core-cuda --load
 docker buildx bake core-cpu --load
+docker buildx bake core-rocm --load
+docker buildx bake core-xpu --load
 
 # Complete image
 docker buildx bake complete-cuda --load
@@ -78,13 +84,13 @@ docker buildx bake runtime-cpu --load
 The project uses a multi-stage build hierarchy:
 
 ```
-runtime-cuda/cpu → core-cuda/cpu → complete-cuda
+runtime-{cuda,cpu,rocm,xpu} → core-{cuda,cpu,rocm,xpu} → complete-cuda
 ```
 
 **Build Stages:**
 1. **Runtime** (`services/runtime/`): Base Ubuntu + CUDA/CPU runtime
 2. **Core** (`services/comfy/core/`): ComfyUI installed at `/app`
-3. **Complete** (`services/comfy/complete/`): Enhanced with custom nodes
+3. **Complete** (`services/comfy/complete/`): Enhanced with common custom-node dependencies
 
 **Tip:** Build base images first for faster iteration:
 ```bash
@@ -118,6 +124,10 @@ Configure builds using environment variables:
 REGISTRY_URL=ghcr.io/myuser/comfyui/
 IMAGE_LABEL=custom
 PLATFORMS=linux/amd64
+COMFYUI_VERSION=v0.33.1                # Stable source tag (the default)
+
+# Explicit nightly build
+COMFYUI_VERSION=master IMAGE_LABEL=nightly docker buildx bake cuda --load
 
 # Build with custom settings
 REGISTRY_URL=myregistry.com/ IMAGE_LABEL=v1.0 docker buildx bake all --load

--- a/docs/user-guides/data.md
+++ b/docs/user-guides/data.md
@@ -10,6 +10,7 @@ All persistent data is stored in `./data/` with subdirectories that map to Comfy
 data/
 ├── models/              → /app/models (AI models, checkpoints, LoRAs)
 ├── custom_nodes/        → /app/custom_nodes (Extensions and plugins)
+├── datasets/            → /app/datasets (Native LoRA trainer datasets)
 ├── input/               → /app/input (Input images and workflows)
 ├── output/              → /app/output (Generated images)
 ├── temp/                → /app/temp (Temporary files)
@@ -22,6 +23,7 @@ data/
 |-----------|---------|------------|
 | `models/` | AI models, checkpoints, LoRAs, VAEs | Read-write (`:rw`) |
 | `custom_nodes/` | Custom node extensions | Read-write (`:rw`) |
+| `datasets/` | Training datasets | Read-write (`:rw`) |
 | `input/` | Input images and workflow files | Read-write (`:rw`) |
 | `output/` | Generated images and results | Read-write (`:rw`) |
 | `temp/` | Temporary processing files | Read-write (`:rw`) |
@@ -44,7 +46,16 @@ data/models/
 ├── clip_vision/        # CLIP vision models
 ├── upscale_models/     # Upscaling models (ESRGAN, etc.)
 ├── style_models/       # Style transfer models
-└── ipadapter/          # IP-Adapter models
+├── diffusion_models/   # Diffusion/UNet model components
+├── text_encoders/      # T5, CLIP, and language encoders
+├── audio_encoders/     # Native audio workflow encoders
+├── latent_upscale_models/
+├── model_patches/
+├── background_removal/
+├── frame_interpolation/
+├── geometry_estimation/
+├── optical_flow/
+└── detection/
 ```
 
 ### Adding Models
@@ -110,7 +121,7 @@ Then restart the container (see [Running Containers](running.md)).
 
 ### Complete Mode
 
-Complete mode includes pre-installed Python dependencies for common custom node setups and SageAttention optimization. Custom nodes can be added by cloning them into `data/custom_nodes/` or through the ComfyUI interface.
+Complete mode includes pre-installed Python dependencies for common custom node setups. Custom nodes can be added by cloning them into `data/custom_nodes/` or through the registry-backed Manager interface.
 
 ## Custom Paths
 
@@ -144,7 +155,7 @@ volumes:
 
 ### Build-Time Ownership
 
-All files under `/app` (including ComfyUI and the Python virtual environment) are owned by a `comfy` user (UID 1000, GID 1000) at build time. The venv `site-packages` directory is world-writable (`a+w`) so ComfyUI Manager can install custom node Python dependencies at runtime regardless of the effective UID.
+All files under `/app` (including ComfyUI and the Python virtual environment) are owned by a `comfy` user (UID 1000, GID 1000) at build time. Package directories under venv `site-packages` and the venv entry-point directory are world-writable so ComfyUI Manager can add, replace, or remove custom-node dependencies regardless of the effective UID.
 
 ### Runtime Ownership
 

--- a/docs/user-guides/features.md
+++ b/docs/user-guides/features.md
@@ -1,0 +1,90 @@
+# Current ComfyUI Feature Support
+
+Audit date: 2026-08-14. The latest stable ComfyUI release at audit time was
+v0.33.1. Repository builds pin that stable source release by default. Scheduled
+image publishing resolves the newest upstream stable tag and also publishes mirrored
+tags such as `core:cuda-v0.33.1`. Set `COMFYUI_VERSION=master` explicitly when
+building a nightly image.
+
+## Release Strategy
+
+The image build uses upstream Git tags directly instead of making `comfy-cli`
+the installer. Both ultimately check out the same repository, but a direct
+tagged clone keeps the Docker layer smaller, makes the selected source visible
+in BuildKit metadata, and lets the image resolve the accelerator-specific
+PyTorch channel before installing ComfyUI requirements.
+
+`comfy-cli` remains valuable for interactive installation, snapshots, models,
+workflow execution, dependency compilation, and version switching. Those are
+mutable workspace operations, whereas a published container should be replaced
+or rolled back by image tag or digest. This split avoids updating application
+source inside a running container and then losing it at the next replacement.
+
+## What the Ecosystem Now Includes
+
+ComfyUI is no longer only a Stable Diffusion image graph. Current upstream
+supports native image, video, audio, 3D, text/LLM, training, and model utility
+workflows. Its frontend now includes App Mode, Nodes 2.0, subgraphs, workflow
+templates, partial execution, embedded node documentation, job progress, and an
+Assets sidebar. Closed-source models are exposed as opt-in Partner Nodes, while
+custom nodes are distributed through the Comfy Registry and current Manager.
+
+## Container Support Matrix
+
+| Capability | Status | Container behavior |
+|---|---|---|
+| Current core nodes and model formats | Supported | Upstream source and every current requirement are installed together |
+| Frontend, templates, embedded docs | Supported | Versioned packages come from upstream `requirements.txt` |
+| App Mode, Nodes 2.0, subgraphs | Supported | No container-specific flags required |
+| Video and audio I/O | Supported | PyAV plus system FFmpeg are installed |
+| Native LoRA training | Supported | `/app/datasets` is persistent |
+| Assets sidebar/index | Enabled | `--enable-assets`; SQLite index persists under `/app/user` |
+| Asset content hashing | Opt-in | Add `--enable-asset-hashing` to `CLI_ARGS` for portable hashes |
+| ComfyUI Manager | Enabled | Official `comfyui_manager` package and registry UI |
+| Partner Nodes | Supported | Outbound network and Comfy account/API-key authentication are required |
+| Server API and jobs API | Supported | Port 8188 by default; all upstream endpoints are unmodified |
+| Multi-user storage | Opt-in | Add `--multi-user` to `CLI_ARGS` |
+| Dynamic VRAM / async offload | Enabled upstream | Add headroom or disable flags only when needed |
+| Comfy Kitchen attention | Opt-in | Add `--use-ck-attention` to `CLI_ARGS` |
+| MCP automation | Separate image | Build/run the `mcp` target and point `COMFYUI_URL` at this service |
+
+## Hardware Matrix
+
+| Hardware | Image tag | Upstream runtime |
+|---|---|---|
+| NVIDIA GPU | `core:cuda-latest`, `complete:cuda-latest` | CUDA 13.0 / PyTorch cu130 |
+| AMD GPU on Linux | `core:rocm-latest` | PyTorch ROCm 7.2 |
+| Intel GPU on Linux | `core:xpu-latest` | PyTorch XPU |
+| CPU | `core:cpu-latest` | PyTorch CPU |
+
+Apple Metal, Windows DirectML, AMD Windows wheels, Ascend, and Cambricon remain
+native/manual-install paths rather than Linux container targets. Containers do
+not virtualize those host driver stacks safely or uniformly.
+
+## Partner Nodes and Remote Access
+
+Partner Nodes are present unless `--disable-api-nodes` is set. Browser account
+login works directly on localhost. For LAN or non-whitelisted origins, use a
+Comfy account API key; for public deployments, terminate TLS at a reverse proxy
+or supply `--tls-keyfile` and `--tls-certfile`. Do not publish an unauthenticated
+ComfyUI port directly to the internet.
+
+Headless clients can place `api_key_comfy_org` in the prompt request's
+`extra_data`. This is intentionally not represented as a container environment
+variable, which avoids putting a paid-service credential into process metadata.
+
+## Persistence Contract
+
+ComfyUI runs with `/app` as its base directory. The examples persist models,
+custom nodes, datasets, input, output, temp, and user state at that same base.
+This also preserves Manager state, workflows, settings, Partner Node login
+state, and the Assets database across image replacement.
+
+## Sources
+
+- [Official documentation index](https://docs.comfy.org/llms.txt)
+- [ComfyUI releases](https://github.com/Comfy-Org/ComfyUI/releases)
+- [Manual installation and hardware backends](https://docs.comfy.org/installation/manual_install)
+- [Partner Nodes](https://docs.comfy.org/tutorials/partner-nodes/overview)
+- [ComfyUI Manager](https://docs.comfy.org/manager/overview)
+- [comfy-cli](https://github.com/Comfy-Org/comfy-cli)

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -21,6 +21,9 @@ Organize models, workflows, custom nodes, and manage persistent storage.
 ### [Performance Tuning](performance.md)
 Optimize ComfyUI for your hardware with CLI arguments and resource configuration.
 
+### [Current Feature Support](features.md)
+See what the modern ComfyUI ecosystem provides and how this image exposes it.
+
 ---
 
-**[⬆ Back to Documentation](../index.md)** 
+**[⬆ Back to Documentation](../index.md)**

--- a/docs/user-guides/performance.md
+++ b/docs/user-guides/performance.md
@@ -12,8 +12,8 @@ ComfyUI provides command-line arguments for performance tuning. Configure via th
 # Standard GPU (8GB+ VRAM) - in .env
 CLI_ARGS=
 
-# Low VRAM systems (4-6GB) - in .env
-CLI_ARGS=--lowvram
+# Leave Dynamic VRAM enabled; reserve additional headroom for the desktop
+CLI_ARGS="--vram-headroom 1"
 
 # Ultra-low VRAM systems (<4GB) - in .env
 CLI_ARGS=--novram
@@ -46,10 +46,13 @@ For complete documentation, see the [ComfyUI Manual Install Guide](https://docs.
 ### Memory Management
 
 ```bash
---lowvram                # For 4-6GB VRAM systems
+--lowvram                # Legacy text-encoder offload when Dynamic VRAM is disabled
 --novram                 # For <4GB VRAM systems (slowest)
 --cpu                    # Force CPU-only mode
 --normalvram             # Normal VRAM usage (default)
+--vram-headroom 1        # Keep an extra 1 GB free for Dynamic VRAM
+--disable-dynamic-vram   # Return to estimate-based model loading
+--fast-disk              # Prefer disk-backed offload on a fast NVMe device
 ```
 
 ### Precision Settings
@@ -67,16 +70,17 @@ For complete documentation, see the [ComfyUI Manual Install Guide](https://docs.
 --use-split-cross-attention     # Split attention (memory efficient)
 --use-quad-cross-attention      # Quad split attention
 --use-pytorch-cross-attention   # PyTorch native attention
+--use-ck-attention              # Maintained Comfy Kitchen attention backend
 --disable-xformers              # Disable xformers optimization
 ```
 
 ### Preview Settings
 
 ```bash
---preview-method auto       # Auto-select preview method (default)
+--preview-method auto       # Auto-select preview method
 --preview-method latent2rgb # Latent2RGB previews
 --preview-method taesd      # TAESD previews (faster)
---preview-method none       # Disable previews (saves memory)
+--preview-method none       # Disable previews (default; saves memory)
 ```
 
 ### Logging
@@ -89,12 +93,12 @@ For complete documentation, see the [ComfyUI Manual Install Guide](https://docs.
 
 ### Low-End GPU (4-6GB VRAM)
 ```bash
-CLI_ARGS=--lowvram --preview-method none --fp16-vae
+CLI_ARGS="--vram-headroom 0.5 --preview-method none --fp16-vae"
 ```
 
 ### Mid-Range GPU (6-8GB VRAM)
 ```bash
-CLI_ARGS=--lowvram --preview-method taesd
+CLI_ARGS="--vram-headroom 1 --preview-method taesd"
 ```
 
 ### High-End GPU (12GB+ VRAM)
@@ -119,22 +123,23 @@ cd examples/core-cpu
 docker compose up -d
 ```
 
-## SageAttention (Complete Mode Only)
+## Current Acceleration Backends
 
-The **Complete** image includes [SageAttention 2.2.0](https://github.com/thu-ml/SageAttention) and [SageAttn3 3.0.0](https://github.com/thu-ml/SageAttention) for 2-3x faster attention computation.
+ComfyUI enables Dynamic VRAM and NVIDIA async offload by default when the
+hardware supports them. It also ships the maintained Comfy Kitchen kernels.
 
 ### Features
 
-- **Automatic activation** - No configuration needed
-- **2-3x faster** - Attention computation speedup
-- **Minimal quality impact** - <1% difference
-- **Smart fallback** - Uses standard attention when needed
-- **Blackwell GPU support** - SageAttn3 supports NVIDIA Blackwell architecture
+- `CLI_ARGS=--use-ck-attention` selects Comfy Kitchen attention.
+- `CLI_ARGS=--fast` enables all experimental optimizations; use named options
+  such as `--fast fp16_accumulation` when you want narrower risk.
+- `CLI_ARGS=--disable-cuda-graphs` disables the current CUDA graph path when a
+  workflow or custom node is incompatible.
 
 ### Verify Installation
 
 ```bash
-docker exec comfyui-complete-gpu python -c "import sageattention; print('SageAttention OK')"
+docker exec comfyui-core-gpu python -c "import torch; print(torch.__version__, torch.version.cuda)"
 ```
 
 ## Docker Resource Limits
@@ -242,18 +247,17 @@ CLI_ARGS=--cpu
 
 - Check GPU is being used: `nvidia-smi`
 - Try different attention mechanism: `CLI_ARGS="--use-pytorch-cross-attention"`
-- Use Complete mode for SageAttention optimization
+- Try `--use-ck-attention` on compatible hardware
 
 ### Container Slow to Start
 
-**Complete mode** has a larger image due to pre-installed Python dependencies and SageAttention. Use Core mode if you don't need the extra optimizations.
+**Complete mode** has a larger image due to pre-installed custom-node dependencies. The core ComfyUI acceleration paths are available in both Core and Complete.
 
 ---
 
 **External Resources:**
 - [ComfyUI CLI Arguments](https://docs.comfy.org/essentials/comfyui_manual_install#optional-setup)
 - [ComfyUI GitHub](https://github.com/comfyanonymous/ComfyUI)
-- [SageAttention](https://github.com/thu-ml/SageAttention)
 
 **See Also:**
 - [Running Containers](running.md) - Set CLI_ARGS via environment variables

--- a/docs/user-guides/quick-start.md
+++ b/docs/user-guides/quick-start.md
@@ -27,7 +27,7 @@ Choose an example directory based on your needs:
 cd examples/core-gpu
 docker compose up -d
 
-# Complete GPU (optimized deps + SageAttention)
+# Complete GPU (common custom-node dependencies)
 cd examples/complete-gpu
 docker compose up -d
 
@@ -45,7 +45,9 @@ Open **http://localhost:8188** in your browser
 | Example | Startup Time | Features | Best For |
 |---------|--------------|----------|----------|
 | **`core-gpu`** | Fast | Essential ComfyUI + GPU | Most users |
-| **`complete-gpu`** | Fast | Pre-installed deps, SageAttention | Power users |
+| **`complete-gpu`** | Fast | Pre-installed custom-node dependencies | Power users |
+| **`core-amd`** | Fast | ROCm 7.2 | Supported AMD GPUs on Linux |
+| **`core-intel`** | Fast | PyTorch XPU | Supported Intel GPUs on Linux |
 | **`core-cpu`** | Fast | No GPU required | Testing, compatibility |
 
 ## First Workflow

--- a/docs/user-guides/running.md
+++ b/docs/user-guides/running.md
@@ -4,13 +4,15 @@ How to run ComfyUI using Docker Compose with profile selection and environment c
 
 ## Deployment Examples
 
-ComfyUI Docker provides three example configurations in the `examples/` directory:
+ComfyUI Docker provides five example configurations in the `examples/` directory:
 
 | Example | Directory | Container | Description |
 |---------|-----------|-----------|-------------|
 | **Core GPU** | `examples/core-gpu` | `comfyui-core-gpu` | Essential ComfyUI with GPU support |
-| **Complete GPU** | `examples/complete-gpu` | `comfyui-complete-gpu` | Pre-installed deps + SageAttention |
+| **Complete GPU** | `examples/complete-gpu` | `comfyui-complete-gpu` | CUDA + pre-installed custom-node dependencies |
 | **Core CPU** | `examples/core-cpu` | `comfyui-core-cpu` | CPU-only mode (no GPU required) |
+| **Core AMD** | `examples/core-amd` | `comfyui-core-amd` | AMD ROCm 7.2 on Linux |
+| **Core Intel** | `examples/core-intel` | `comfyui-core-intel` | Intel XPU on Linux |
 
 ### Starting Services
 
@@ -74,6 +76,11 @@ COMFY_MODEL_PATH=./data/models
 COMFY_OUTPUT_PATH=./data/output
 COMFY_TEMP_PATH=./data/temp
 COMFY_USER_PATH=./data/user
+COMFY_DATASET_PATH=./data/datasets
+
+# Built-in services
+COMFY_ENABLE_MANAGER=true
+COMFY_ENABLE_ASSETS=true
 
 # Performance (see Performance Tuning guide)
 CLI_ARGS=--preview-method auto
@@ -119,13 +126,16 @@ COMFY_MODEL_PATH=./data/models              # AI models
 COMFY_OUTPUT_PATH=./data/output             # Generated content
 COMFY_TEMP_PATH=./data/temp                 # Temporary files
 COMFY_USER_PATH=./data/user                 # User configs
+COMFY_DATASET_PATH=./data/datasets          # Native trainer datasets
 ```
 
 See [Data Management](data.md) for details on directory structure.
 
 #### Performance & Optional
 ```bash
-CLI_ARGS="--lowvram"         # ComfyUI launch arguments
+COMFY_ENABLE_MANAGER=true     # Registry-backed Manager UI and endpoints
+COMFY_ENABLE_ASSETS=true      # Assets API/sidebar and persistent index
+CLI_ARGS="--vram-headroom 1" # Additional ComfyUI launch arguments
 COMFY_IMAGE=custom:latest    # Override Docker image
 ```
 
@@ -283,7 +293,7 @@ See [Data Management](data.md) for file permission details.
 nvidia-smi
 
 # Test Docker GPU support
-docker run --rm --gpus all nvidia/cuda:12.9.1-runtime-ubuntu24.04 nvidia-smi
+docker run --rm --gpus all nvidia/cuda:13.0.2-runtime-ubuntu24.04 nvidia-smi
 ```
 
 See [Performance Tuning](performance.md) for GPU optimization.

--- a/examples/complete-gpu/.env.example
+++ b/examples/complete-gpu/.env.example
@@ -12,9 +12,13 @@ PGID=1000
 #=====================================================================#
 
 COMFY_PORT=8188
+COMFY_ENABLE_MANAGER=true
+COMFY_ENABLE_ASSETS=true
+CLI_ARGS=
 
 # Individual path configuration
 COMFY_CUSTOM_NODE_PATH=./data/custom_nodes
+COMFY_DATASET_PATH=./data/datasets
 COMFY_INPUT_PATH=./data/input
 COMFY_MODEL_PATH=./data/models
 COMFY_OUTPUT_PATH=./data/output

--- a/examples/complete-gpu/README.md
+++ b/examples/complete-gpu/README.md
@@ -5,7 +5,9 @@ This example starts the **Complete** ComfyUI image in **GPU (CUDA)** mode.
 
 **Use Case:**
 - Full-featured environment.
-- Pre-installed system & Python dependencies for heavy nodes (e.g. SageAttention modules/wheels).
+- Pre-installed system and Python dependencies shared by common custom nodes.
+- ComfyUI's maintained Comfy Kitchen attention backend is available with
+  `CLI_ARGS=--use-ck-attention`.
 - **Does NOT** include pre-installed custom nodes (use Runtime Lock for that).
 
 ## Prerequisite

--- a/examples/complete-gpu/docker-compose.yml
+++ b/examples/complete-gpu/docker-compose.yml
@@ -1,17 +1,21 @@
 services:
   comfyui:
-    image: ghcr.io/pixeloven/comfyui/complete:cuda-latest
+    image: ${COMFY_IMAGE:-ghcr.io/pixeloven/comfyui/complete:cuda-latest}
     container_name: comfyui-complete-gpu
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
       - COMFY_PORT=${COMFY_PORT:-8188}
+      - COMFY_ENABLE_MANAGER=${COMFY_ENABLE_MANAGER:-true}
+      - COMFY_ENABLE_ASSETS=${COMFY_ENABLE_ASSETS:-true}
+      - CLI_ARGS=${CLI_ARGS:-}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     ports:
-      - "${COMFY_PORT:-8188}:8188"
+      - "${COMFY_PORT:-8188}:${COMFY_PORT:-8188}"
     volumes:
       - ${COMFY_CUSTOM_NODE_PATH:-./data/custom_nodes}:/app/custom_nodes
+      - ${COMFY_DATASET_PATH:-./data/datasets}:/app/datasets
       - ${COMFY_INPUT_PATH:-./data/input}:/app/input
       - ${COMFY_OUTPUT_PATH:-./data/output}:/app/output
       - ${COMFY_MODEL_PATH:-./data/models}:/app/models

--- a/examples/complete-gpu/extra_model_paths.yaml
+++ b/examples/complete-gpu/extra_model_paths.yaml
@@ -4,6 +4,6 @@
 # Unified volume-based paths for persistence across container restarts
 comfyui:
   is_default: true
-  base_path: /data
-  download_model_base: /data/comfy/models
-  custom_nodes: /data/comfy/custom_nodes
+  base_path: /app
+  download_model_base: /app/models
+  custom_nodes: /app/custom_nodes

--- a/examples/core-amd/.env.example
+++ b/examples/core-amd/.env.example
@@ -1,0 +1,20 @@
+PUID=1000
+PGID=1000
+COMFY_PORT=8188
+COMFY_ENABLE_MANAGER=true
+COMFY_ENABLE_ASSETS=true
+CLI_ARGS=
+
+# Use `getent group video` and `getent group render` on the host.
+VIDEO_GID=44
+RENDER_GID=109
+# Only set this compatibility override when your ROCm GPU requires it.
+HSA_OVERRIDE_GFX_VERSION=
+
+COMFY_CUSTOM_NODE_PATH=./data/custom_nodes
+COMFY_DATASET_PATH=./data/datasets
+COMFY_INPUT_PATH=./data/input
+COMFY_MODEL_PATH=./data/models
+COMFY_OUTPUT_PATH=./data/output
+COMFY_TEMP_PATH=./data/temp
+COMFY_USER_PATH=./data/user

--- a/examples/core-amd/README.md
+++ b/examples/core-amd/README.md
@@ -1,0 +1,13 @@
+# Core AMD (ROCm)
+
+Linux deployment for supported AMD GPUs using the upstream PyTorch ROCm 7.2
+wheels. The host must expose `/dev/kfd` and `/dev/dri`.
+
+```bash
+cp .env.example .env
+# Adjust VIDEO_GID and RENDER_GID to match the host, then:
+docker compose up -d
+```
+
+See the official [ComfyUI manual installation hardware notes](https://docs.comfy.org/installation/manual_install)
+for the current supported GPU generations and optional compatibility settings.

--- a/examples/core-amd/docker-compose.yml
+++ b/examples/core-amd/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   comfyui:
-    image: ${COMFY_IMAGE:-ghcr.io/pixeloven/comfyui/core:cuda-latest}
-    container_name: comfyui-core-gpu
+    image: ${COMFY_IMAGE:-ghcr.io/pixeloven/comfyui/core:rocm-latest}
+    container_name: comfyui-core-amd
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
@@ -9,10 +9,17 @@ services:
       - COMFY_ENABLE_MANAGER=${COMFY_ENABLE_MANAGER:-true}
       - COMFY_ENABLE_ASSETS=${COMFY_ENABLE_ASSETS:-true}
       - CLI_ARGS=${CLI_ARGS:-}
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}
     ports:
       - "${COMFY_PORT:-8188}:${COMFY_PORT:-8188}"
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-109}"
+    security_opt:
+      - seccomp=unconfined
     volumes:
       - ${COMFY_CUSTOM_NODE_PATH:-./data/custom_nodes}:/app/custom_nodes
       - ${COMFY_DATASET_PATH:-./data/datasets}:/app/datasets
@@ -21,19 +28,5 @@ services:
       - ${COMFY_MODEL_PATH:-./data/models}:/app/models
       - ${COMFY_TEMP_PATH:-./data/temp}:/app/temp
       - ${COMFY_USER_PATH:-./data/user}:/app/user
-      # (Optional) Configuration
       - ./extra_model_paths.yaml:/app/extra_model_paths.yaml:ro
     restart: unless-stopped
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [ gpu ]
-    networks:
-      - comfy_network
-
-networks:
-  comfy_network:
-    driver: bridge

--- a/examples/core-amd/extra_model_paths.yaml
+++ b/examples/core-amd/extra_model_paths.yaml
@@ -1,0 +1,5 @@
+comfyui:
+  is_default: true
+  base_path: /app
+  download_model_base: /app/models
+  custom_nodes: /app/custom_nodes

--- a/examples/core-cpu/.env.example
+++ b/examples/core-cpu/.env.example
@@ -12,9 +12,13 @@ PGID=1000
 #=====================================================================#
 
 COMFY_PORT=8188
+COMFY_ENABLE_MANAGER=true
+COMFY_ENABLE_ASSETS=true
+CLI_ARGS=
 
 # Individual path configuration
 COMFY_CUSTOM_NODE_PATH=./data/custom_nodes
+COMFY_DATASET_PATH=./data/datasets
 COMFY_INPUT_PATH=./data/input
 COMFY_MODEL_PATH=./data/models
 COMFY_OUTPUT_PATH=./data/output

--- a/examples/core-cpu/docker-compose.yml
+++ b/examples/core-cpu/docker-compose.yml
@@ -1,16 +1,19 @@
 services:
   comfyui:
-    image: ghcr.io/pixeloven/comfyui/core:cpu-latest
+    image: ${COMFY_IMAGE:-ghcr.io/pixeloven/comfyui/core:cpu-latest}
     container_name: comfyui-core-cpu
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
       - COMFY_PORT=${COMFY_PORT:-8188}
-      - CLI_ARGS=--cpu
+      - COMFY_ENABLE_MANAGER=${COMFY_ENABLE_MANAGER:-true}
+      - COMFY_ENABLE_ASSETS=${COMFY_ENABLE_ASSETS:-true}
+      - CLI_ARGS=${CLI_ARGS:-}
     ports:
-      - "${COMFY_PORT:-8188}:8188"
+      - "${COMFY_PORT:-8188}:${COMFY_PORT:-8188}"
     volumes:
       - ${COMFY_CUSTOM_NODE_PATH:-./data/custom_nodes}:/app/custom_nodes
+      - ${COMFY_DATASET_PATH:-./data/datasets}:/app/datasets
       - ${COMFY_INPUT_PATH:-./data/input}:/app/input
       - ${COMFY_MODEL_PATH:-./data/models}:/app/models
       - ${COMFY_OUTPUT_PATH:-./data/output}:/app/output

--- a/examples/core-cpu/extra_model_paths.yaml
+++ b/examples/core-cpu/extra_model_paths.yaml
@@ -4,6 +4,6 @@
 # Unified volume-based paths for persistence across container restarts
 comfyui:
   is_default: true
-  base_path: /data
-  download_model_base: /data/comfy/models
-  custom_nodes: /data/comfy/custom_nodes
+  base_path: /app
+  download_model_base: /app/models
+  custom_nodes: /app/custom_nodes

--- a/examples/core-gpu/.env.example
+++ b/examples/core-gpu/.env.example
@@ -12,9 +12,13 @@ PGID=1000
 #=====================================================================#
 
 COMFY_PORT=8188
+COMFY_ENABLE_MANAGER=true
+COMFY_ENABLE_ASSETS=true
+CLI_ARGS=
 
 # Individual path configuration
 COMFY_CUSTOM_NODE_PATH=./data/custom_nodes
+COMFY_DATASET_PATH=./data/datasets
 COMFY_INPUT_PATH=./data/input
 COMFY_MODEL_PATH=./data/models
 COMFY_OUTPUT_PATH=./data/output

--- a/examples/core-gpu/extra_model_paths.yaml
+++ b/examples/core-gpu/extra_model_paths.yaml
@@ -4,6 +4,6 @@
 # Unified volume-based paths for persistence across container restarts
 comfyui:
   is_default: true
-  base_path: /data
-  download_model_base: /data/comfy/models
-  custom_nodes: /data/comfy/custom_nodes
+  base_path: /app
+  download_model_base: /app/models
+  custom_nodes: /app/custom_nodes

--- a/examples/core-intel/.env.example
+++ b/examples/core-intel/.env.example
@@ -1,0 +1,18 @@
+PUID=1000
+PGID=1000
+COMFY_PORT=8188
+COMFY_ENABLE_MANAGER=true
+COMFY_ENABLE_ASSETS=true
+CLI_ARGS=
+
+# Use `getent group video` and `getent group render` on the host.
+VIDEO_GID=44
+RENDER_GID=109
+
+COMFY_CUSTOM_NODE_PATH=./data/custom_nodes
+COMFY_DATASET_PATH=./data/datasets
+COMFY_INPUT_PATH=./data/input
+COMFY_MODEL_PATH=./data/models
+COMFY_OUTPUT_PATH=./data/output
+COMFY_TEMP_PATH=./data/temp
+COMFY_USER_PATH=./data/user

--- a/examples/core-intel/README.md
+++ b/examples/core-intel/README.md
@@ -1,0 +1,13 @@
+# Core Intel (XPU)
+
+Linux deployment for Intel Arc GPUs using the upstream PyTorch XPU wheels. The
+host must expose `/dev/dri` and have a current Intel compute runtime and driver.
+
+```bash
+cp .env.example .env
+# Adjust VIDEO_GID and RENDER_GID to match the host, then:
+docker compose up -d
+```
+
+Use `CLI_ARGS=--oneapi-device-selector=...` when a host has multiple Intel
+devices and a specific selector is required.

--- a/examples/core-intel/docker-compose.yml
+++ b/examples/core-intel/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   comfyui:
-    image: ${COMFY_IMAGE:-ghcr.io/pixeloven/comfyui/core:cuda-latest}
-    container_name: comfyui-core-gpu
+    image: ${COMFY_IMAGE:-ghcr.io/pixeloven/comfyui/core:xpu-latest}
+    container_name: comfyui-core-intel
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
@@ -9,10 +9,13 @@ services:
       - COMFY_ENABLE_MANAGER=${COMFY_ENABLE_MANAGER:-true}
       - COMFY_ENABLE_ASSETS=${COMFY_ENABLE_ASSETS:-true}
       - CLI_ARGS=${CLI_ARGS:-}
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     ports:
       - "${COMFY_PORT:-8188}:${COMFY_PORT:-8188}"
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-109}"
     volumes:
       - ${COMFY_CUSTOM_NODE_PATH:-./data/custom_nodes}:/app/custom_nodes
       - ${COMFY_DATASET_PATH:-./data/datasets}:/app/datasets
@@ -21,19 +24,5 @@ services:
       - ${COMFY_MODEL_PATH:-./data/models}:/app/models
       - ${COMFY_TEMP_PATH:-./data/temp}:/app/temp
       - ${COMFY_USER_PATH:-./data/user}:/app/user
-      # (Optional) Configuration
       - ./extra_model_paths.yaml:/app/extra_model_paths.yaml:ro
     restart: unless-stopped
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [ gpu ]
-    networks:
-      - comfy_network
-
-networks:
-  comfy_network:
-    driver: bridge

--- a/examples/core-intel/extra_model_paths.yaml
+++ b/examples/core-intel/extra_model_paths.yaml
@@ -1,0 +1,5 @@
+comfyui:
+  is_default: true
+  base_path: /app
+  download_model_base: /app/models
+  custom_nodes: /app/custom_nodes

--- a/services/comfy/complete/dockerfile.comfy.cuda.complete
+++ b/services/comfy/complete/dockerfile.comfy.cuda.complete
@@ -12,9 +12,7 @@ RUN --mount=type=cache,mode=0755,uid=1000,gid=1000,target=/app/.cache/pip \
     source $VENV_PATH/bin/activate && \
     pip install -r extra-requirements.txt
 
-# Re-apply world-writable permissions after installing extra packages.
-# The core stage's chmod doesn't cover files added in this layer — newly
-# installed packages and entry point scripts would be root-owned 644/755.
+# Re-apply writable directory permissions after installing extra packages.
 RUN PYTHON_VERSION=$(python3 -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')") && \
-    chmod -R a+w /app/.venv/lib/${PYTHON_VERSION}/site-packages && \
+    find /app/.venv/lib/${PYTHON_VERSION}/site-packages -type d -exec chmod a+w {} + && \
     chmod a+w /app/.venv/bin

--- a/services/comfy/complete/extra-requirements.txt
+++ b/services/comfy/complete/extra-requirements.txt
@@ -56,10 +56,10 @@ groundingdino-py>=0.4.0
 # Core acceleration libraries (pre-built wheels)
 # triton>=3.4
 
-# SageAttention 2.2.0 + SageAttn3 1.0.0 (pre-built) - CUDA 12.9.1 + Python 3.12 (build.15)
-# Provides: sageattention (SM80+), sageattn3 (Blackwell/SM100+)
-https://github.com/pixeloven/SageAttention/releases/download/v2.2.0-build.16/sageattention-2.2.0-290.129-cp312-cp312-linux_x86_64.whl
-https://github.com/pixeloven/SageAttention/releases/download/v2.2.0-build.16/sageattn3-1.0.0-290.129-cp312-cp312-linux_x86_64.whl
+# ComfyUI now ships its maintained Comfy Kitchen attention backend and CUDA
+# graph support. The old SageAttention wheels were compiled for PyTorch 2.9 /
+# CUDA 12.9 and cannot be loaded by the current cu130 runtime. Users can select
+# the maintained backend with CLI_ARGS="--use-ck-attention".
 
 PyYAML
 

--- a/services/comfy/core/dockerfile.comfy.core
+++ b/services/comfy/core/dockerfile.comfy.core
@@ -21,23 +21,24 @@ RUN umask 022 && \
 # We clone into a temporary directory and move to /app/ComfyUI to prevent
 # permission issues if we were to mount /app entirely in dev modes
 ARG RUNTIME=cuda
+ARG COMFYUI_VERSION=v0.33.1
 
 # CUDA wheel index for the torch family (torch / torchaudio / torchvision).
-# Defaults to cu128 for the cuda target; the cpu target overrides this to
-# "cpu" via docker-bake.hcl. Future cuda variants (cu130, etc.) can be
-# added by introducing a new bake target with `args = { TORCH_INDEX = "cu130" }`.
-ARG TORCH_INDEX=cu128
+# Defaults to the current stable NVIDIA channel. CPU, ROCm, and XPU targets
+# override this through docker-bake.hcl.
+ARG TORCH_INDEX=cu130
 
 RUN --mount=type=cache,target=/app/.cache/pip \
   umask 022 && \
-  git clone https://github.com/comfyanonymous/ComfyUI.git /app/ComfyUI && \
+  git clone --depth 1 --branch "$COMFYUI_VERSION" \
+    https://github.com/Comfy-Org/ComfyUI.git /app/ComfyUI && \
   # Install torch family from the wheel index ONLY (not --extra-index-url).
   # --extra-index-url is additive, so pip picks the highest version across
   # PyPI + the index. When PyPI ships a newer torch than the cu* index
   # (which happens regularly), pip picks the PyPI build, leaving torch and
   # torchaudio compiled against different CUDA versions. Using --index-url
   # replaces PyPI for this command, so resolution is constrained to the
-  # specified index and the CUDA ABI stays consistent across all three.
+  # specified index and the accelerator ABI stays consistent across the set.
   pip install --index-url https://download.pytorch.org/whl/${TORCH_INDEX} \
     torch torchaudio torchvision && \
   # Install the rest of ComfyUI's requirements normally. torch, torchaudio,
@@ -50,6 +51,12 @@ RUN --mount=type=cache,target=/app/.cache/pip \
 # Final Stage
 # ==================================================================
 FROM runtime AS core
+
+ARG COMFYUI_VERSION=v0.33.1
+ARG RUNTIME=cuda
+
+LABEL org.opencontainers.image.source="https://github.com/Comfy-Org/ComfyUI" \
+      org.opencontainers.image.version="$COMFYUI_VERSION"
 
 # Set shell to bash with pipefail for safety (not inherited across FROM)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -82,6 +89,8 @@ ENV XDG_CACHE_HOME=/app/.cache
 # Suppress .pyc writes — avoids silent permission failures when running
 # as an arbitrary UID that can't write to source directories
 ENV PYTHONDONTWRITEBYTECODE=1
+ENV COMFYUI_VERSION=$COMFYUI_VERSION
+ENV COMFY_RUNTIME=$RUNTIME
 
 # Copy startup scripts to app root
 COPY --chown=comfy:comfy startup.sh entrypoint.sh /app/
@@ -94,17 +103,35 @@ RUN chmod +x /app/startup.sh /app/entrypoint.sh
 #
 # Detect the Python version dynamically to avoid hardcoding python3.12
 # Writable targets:
-#   - site-packages: ComfyUI Manager installs custom node deps at runtime
+#   - site-packages directories: pip/uv can add, replace, and remove packages
+#     without copying every static workflow-template asset into this layer
 #   - venv/bin: pip-installed packages create entry point scripts here
 #   - .cache: uv/pip cache operations
 #   - ComfyUI data dirs: ComfyUI creates these at startup if missing
 #   - /etc/passwd, /etc/group: entrypoint injects entries for arbitrary UIDs
 #     so getpwuid(), getgrgid(), getpass.getuser(), expanduser("~") all work
 RUN PYTHON_VERSION=$(python3 -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')") && \
-  chmod -R a+w /app/.venv/lib/${PYTHON_VERSION}/site-packages && \
+  find /app/.venv/lib/${PYTHON_VERSION}/site-packages -type d -exec chmod a+w {} + && \
   chmod a+w /app/.venv/lib/${PYTHON_VERSION} && \
   chmod a+w /app/.venv/bin && \
-  mkdir -p /app/.cache && chmod -R a+w /app/.cache && \
+  mkdir -p \
+    /app/.cache \
+    /app/models \
+    /app/custom_nodes \
+    /app/datasets \
+    /app/input \
+    /app/output \
+    /app/temp \
+    /app/user && \
+  chmod -R a+w /app/.cache && \
+  chmod a+rwx \
+    /app/models \
+    /app/custom_nodes \
+    /app/datasets \
+    /app/input \
+    /app/output \
+    /app/temp \
+    /app/user && \
   chmod a+w /app /app/ComfyUI && \
   chmod a+w /etc/passwd /etc/group
 

--- a/services/comfy/core/entrypoint.sh
+++ b/services/comfy/core/entrypoint.sh
@@ -85,12 +85,21 @@ fi
 # Directory Ownership
 # =============================================================================
 
-# Set ownership of application root directories
+# Set ownership of application and persistent volume roots. Keep this
+# non-recursive: model stores can contain terabytes of data.
 chown "$PUID:$PGID" /app /app/ComfyUI
-
-# Set ownership of immediate subdirectories (handles volume mount points)
-# Non-recursive for performance — avoids traversing large model directories
-find /app/ComfyUI -maxdepth 1 -mindepth 1 -type d -exec chown "$PUID:$PGID" {} +
+for directory in \
+    /app/models \
+    /app/custom_nodes \
+    /app/datasets \
+    /app/input \
+    /app/output \
+    /app/temp \
+    /app/user; do
+    if [ -d "$directory" ]; then
+        chown "$PUID:$PGID" "$directory"
+    fi
+done
 
 # =============================================================================
 # Startup Logging

--- a/services/comfy/core/startup.sh
+++ b/services/comfy/core/startup.sh
@@ -1,4 +1,38 @@
 #!/bin/bash
 set -e
 
-exec python main.py --listen --port $COMFY_PORT --enable-manager $CLI_ARGS
+args=(
+    main.py
+    --listen
+    --port "${COMFY_PORT:-8188}"
+    --base-directory /app
+    --database-url sqlite:////app/user/comfyui.db
+)
+
+if [ "${COMFY_RUNTIME:-cuda}" = "cpu" ]; then
+    args+=(--cpu)
+fi
+
+# Manager is an upstream package and is enabled by default in these images.
+if [ "${COMFY_ENABLE_MANAGER:-true}" = "true" ]; then
+    args+=(--enable-manager)
+fi
+
+# The assets API and index back the current Assets sidebar. Hashing remains an
+# explicit opt-in because it can make startup expensive on large model stores.
+if [ "${COMFY_ENABLE_ASSETS:-true}" = "true" ]; then
+    args+=(--enable-assets)
+fi
+
+if [ -f /app/extra_model_paths.yaml ]; then
+    args+=(--extra-model-paths-config /app/extra_model_paths.yaml)
+fi
+
+# CLI_ARGS is intentionally a whitespace-delimited escape hatch. Prefer the
+# dedicated environment variables above for built-in container behavior.
+if [ -n "${CLI_ARGS:-}" ]; then
+    read -r -a extra_args <<< "$CLI_ARGS"
+    args+=("${extra_args[@]}")
+fi
+
+exec python "${args[@]}"

--- a/services/runtime/dockerfile.cuda.runtime
+++ b/services/runtime/dockerfile.cuda.runtime
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.9.1-base-ubuntu24.04 AS runtime-nvidia
+FROM nvidia/cuda:13.0.2-base-ubuntu24.04 AS runtime-nvidia
 
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary

- pin image builds to stable ComfyUI release tags while retaining explicit nightly/master builds
- add NVIDIA CUDA 13, AMD ROCm 7.2, Intel XPU, and CPU build paths
- enable current ComfyUI Manager, Assets, persistent database, datasets, model paths, and Comfy Kitchen features
- document the current ComfyUI ecosystem and update Compose examples and operator guides
- update GitHub workflows to the current checkout and Docker action major versions

## Validation completed

- [x] build and load the core CPU image
- [x] start ComfyUI 0.33.1 and verify Manager, Assets migrations, frontend, templates, embedded docs, and model scans
- [x] validate arbitrary UID operation and writable extension installation
- [x] validate all Compose examples, workflow YAML, shell syntax, Bake configuration, and diff formatting
- [x] verify stable tags include the mirrored ComfyUI version and `latest`
- [x] verify nightly/master builds cannot overwrite stable `latest` tags
- [x] build the full CUDA image stack in CI
- [x] build the full ROCm image stack in CI
- [x] build the full Intel XPU image stack in CI
- [x] complete all PR checks successfully
- [ ] run inference against physical NVIDIA, AMD, and Intel GPUs

The draft remains open for hardware-backed runtime testing. The current development host exposes only a Virtio display device, so accelerator image construction is proven but physical-device execution requires suitable runners.