### PR TITLE
fix(resolve): report every unresolved source, not just the first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,44 @@ jobs:
         git checkout -- comfy.yaml
         echo "selftest ok: rejects an unhashed entry, an undeclared one, a bad profile member, and a cycle"
 
+    - name: Selftest — resolve reports EVERY bad source, in one pass
+      # A manifest of 161 files with one dead source used to resolve nothing and
+      # report a single problem, so finding N broken sources cost N full passes
+      # over the network. This asserts all of them surface at once, and that no
+      # partial lock is written -- one that looks complete is worse than none.
+      run: |
+        set -u
+        cat > /tmp/bad.yaml <<'YAML'
+        name: selftest
+        models:
+          - name: dead-civitai
+            files:
+              - source: civitai:2068000
+                as: gone.safetensors
+                install: models/unet/
+          - name: bad-repo
+            files:
+              - source: hf:does-not-exist-xyz/nope
+                file: nope.safetensors
+                install: models/loras/
+          - name: url-without-hash
+            files:
+              - source: https://example.com/thing.safetensors
+                install: models/loras/
+        YAML
+        if sh services/fetch/resolve.sh /tmp/bad.yaml > /tmp/bad.lock 2> /tmp/bad.err; then
+          echo "SELFTEST FAILED: resolve succeeded against three broken sources"; exit 1
+        fi
+        if [ -s /tmp/bad.lock ]; then
+          echo "SELFTEST FAILED: a partial lock was written"; cat /tmp/bad.lock; exit 1
+        fi
+        for want in "civitai:2068000" "does-not-exist-xyz" "needs \`sha256\`"; do
+          grep -qF "$want" /tmp/bad.err || {
+            echo "SELFTEST FAILED: '$want' missing from the report"; cat /tmp/bad.err; exit 1
+          }
+        done
+        echo "selftest ok: all three failures reported in one pass, no lock written"
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
@@ -157,6 +195,44 @@ jobs:
     needs: validate-models
     steps:
     - uses: actions/checkout@v7
+
+    - name: Selftest — resolve reports EVERY bad source, in one pass
+      # A manifest of 161 files with one dead source used to resolve nothing and
+      # report a single problem, so finding N broken sources cost N full passes
+      # over the network. This asserts all of them surface at once, and that no
+      # partial lock is written -- one that looks complete is worse than none.
+      run: |
+        set -u
+        cat > /tmp/bad.yaml <<'YAML'
+        name: selftest
+        models:
+          - name: dead-civitai
+            files:
+              - source: civitai:2068000
+                as: gone.safetensors
+                install: models/unet/
+          - name: bad-repo
+            files:
+              - source: hf:does-not-exist-xyz/nope
+                file: nope.safetensors
+                install: models/loras/
+          - name: url-without-hash
+            files:
+              - source: https://example.com/thing.safetensors
+                install: models/loras/
+        YAML
+        if sh services/fetch/resolve.sh /tmp/bad.yaml > /tmp/bad.lock 2> /tmp/bad.err; then
+          echo "SELFTEST FAILED: resolve succeeded against three broken sources"; exit 1
+        fi
+        if [ -s /tmp/bad.lock ]; then
+          echo "SELFTEST FAILED: a partial lock was written"; cat /tmp/bad.lock; exit 1
+        fi
+        for want in "civitai:2068000" "does-not-exist-xyz" "needs \`sha256\`"; do
+          grep -qF "$want" /tmp/bad.err || {
+            echo "SELFTEST FAILED: '$want' missing from the report"; cat /tmp/bad.err; exit 1
+          }
+        done
+        echo "selftest ok: all three failures reported in one pass, no lock written"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/services/fetch/resolve.sh
+++ b/services/fetch/resolve.sh
@@ -22,6 +22,13 @@
 
 set -eu
 
+# Source failures are COLLECTED, not fatal. `set -e` aborting on the first one
+# means a manifest of 161 files with a single dead source resolves nothing and
+# tells you about one problem per run -- so finding N broken sources costs N
+# full passes over the network. Every failure is reported in one pass instead,
+# and no lock is written unless all of them resolved: a partial lock that looks
+# complete is worse than none.
+
 LC_ALL=C
 export LC_ALL
 
@@ -81,6 +88,15 @@ else
   declared="$(yq -r '[.models[].files[]] | length' "$MANIFEST")"
 fi
 records=0
+failures=0
+failed_list=""
+
+fail() {  # <what> ; records the failure and moves on
+  echo "  UNRESOLVED  $1" >&2
+  failed_list="${failed_list}  $1
+"
+  failures=$((failures + 1))
+}
 
 hf_head() {  # <repo> <revision> <file>  -> commit<TAB>sha256
   # NOT -sIL. `x-linked-etag` is the sha256 only on the FIRST hop; following the
@@ -118,9 +134,9 @@ while read -r marker; do
   case "$source" in
     hf:*)
       repo="${source#hf:}"
-      [ -n "$file" ] || { echo "hf source needs \`file\`: $source" >&2; exit 1; }
+      if [ -z "$file" ]; then fail "$source: hf source needs \`file\`"; continue; fi
       got="$(hf_head "$repo" "$revision" "$file")"
-      [ -n "$got" ] || { echo "could not resolve hf:$repo@$revision/$file" >&2; exit 1; }
+      if [ -z "$got" ]; then fail "hf:$repo@$revision/$file: not found, or gated and no token"; continue; fi
       commit="$(printf '%s' "$got" | cut -f1)"
       sha="$(printf '%s' "$got" | cut -f2)"
       # The lock pins the COMMIT, never the moving ref it was resolved from.
@@ -129,28 +145,30 @@ while read -r marker; do
       ;;
     civitai:*)
       id="${source#civitai:}"
-      curl -sf -A "$UA" "https://civitai.com/api/v1/model-versions/$id" > "$work/cv.json" \
-        || { echo "could not resolve $source" >&2; exit 1; }
+      if ! curl -sf -A "$UA" "https://civitai.com/api/v1/model-versions/$id" > "$work/cv.json"; then
+        fail "$source: not found (deleted upstream, or the version id is wrong)"; continue
+      fi
       url="$(yq -p json -o yaml -r '.files[0].downloadUrl' "$work/cv.json")"
       sha="$(yq -p json -o yaml -r '.files[0].hashes.SHA256 // ""' "$work/cv.json" | tr '[:upper:]' '[:lower:]')"
       base="$(yq -p json -o yaml -r '.files[0].name' "$work/cv.json")"
       # `if`, not `A && B || C` -- the latter runs C when A is true and B is
       # false, which is not if-then-else and would misreport the reason.
       if [ -z "$sha" ] || [ "$sha" = "null" ]; then
-        echo "$source has no SHA256" >&2; exit 1
+        fail "$source: no SHA256 in the API response"; continue
       fi
       ;;
     gh:*)
       # gh:<owner>/<repo>@<tag>. The asset is `file`.
       spec="${source#gh:}"; repo="${spec%@*}"; tag="${spec##*@}"
-      [ -n "$file" ] || { echo "gh source needs \`file\` (the asset name): $source" >&2; exit 1; }
+      if [ -z "$file" ]; then fail "$source: gh source needs \`file\` (the asset name)"; continue; fi
       set --
       if [ -n "${GITHUB_TOKEN:-}" ]; then set -- -H "Authorization: Bearer $GITHUB_TOKEN"; fi
-      curl -sf -A "$UA" "$@" "https://api.github.com/repos/$repo/releases/tags/$tag" > "$work/gh.json" \
-        || { echo "could not read release $repo@$tag" >&2; exit 1; }
+      if ! curl -sf -A "$UA" "$@" "https://api.github.com/repos/$repo/releases/tags/$tag" > "$work/gh.json"; then
+        fail "gh:$repo@$tag: release not found"; continue
+      fi
       url="$(ASSET="$file" yq -p json -o yaml -r '.assets[] | select(.name == strenv(ASSET)) | .browser_download_url' "$work/gh.json")"
       if [ -z "$url" ] || [ "$url" = "null" ]; then
-        echo "no asset named $file in $repo@$tag" >&2; exit 1
+        fail "gh:$repo@$tag: no asset named $file"; continue
       fi
       digest="$(ASSET="$file" yq -p json -o yaml -r '.assets[] | select(.name == strenv(ASSET)) | .digest // ""' "$work/gh.json")"
       if [ -n "$digest" ] && [ "$digest" != "null" ]; then
@@ -162,8 +180,9 @@ while read -r marker; do
         # would defeat the point -- but it is avoidable by stating `sha256` in
         # the manifest.
         echo "no digest for $file in $repo@$tag; downloading to hash it (state \`sha256\` to skip)" >&2
-        curl -fsSL -A "$UA" "$url" -o "$work/asset" \
-          || { echo "could not download $url" >&2; exit 1; }
+        if ! curl -fsSL -A "$UA" "$url" -o "$work/asset"; then
+          fail "gh:$repo@$tag/$file: download failed"; continue
+        fi
         sha="$(sha256sum "$work/asset" | cut -d' ' -f1)"
         rm -f "$work/asset"
       fi
@@ -173,11 +192,11 @@ while read -r marker; do
       # Nothing about a bare URL can be resolved from headers, so the manifest
       # must state the hash. Refusing is the honest outcome: writing a lock
       # entry with no hash would produce a fetch that verifies nothing.
-      [ -n "$sha" ] || { echo "direct URL needs \`sha256\` in the manifest: $source" >&2; exit 1; }
+      if [ -z "$sha" ]; then fail "$source: a direct URL needs \`sha256\` in the manifest"; continue; fi
       url="$source"
       base="$(basename "${source%%\?*}")"
       ;;
-    *) echo "unknown source scheme: $source" >&2; exit 1 ;;
+    *) fail "$source: unknown source scheme"; continue ;;
   esac
 
   if [ -n "$as" ]; then base="$as"; fi
@@ -191,6 +210,16 @@ EOF
 
 # Reading zero records from a manifest that declares files must never be
 # reported as success.
+if [ "$failures" != 0 ]; then
+  echo "" >&2
+  echo "$failures of $declared sources did not resolve:" >&2
+  printf '%s' "$failed_list" >&2
+  echo "" >&2
+  echo "No lock written. Fix the manifest and re-run -- every failure above is" >&2
+  echo "reported in this one pass, so this should not need repeating." >&2
+  exit 1
+fi
+
 if [ "$records" != "$declared" ]; then
   echo "read $records records but the manifest declares $declared files" >&2
   exit 3


### PR DESCRIPTION
Found while resolving a real 161-file manifest.

`set -e` made the first bad source fatal: **30 files resolved, nothing was emitted, and the run reported exactly one problem.** Discovering N broken sources would have cost N full passes over the network, each re-resolving everything that already worked.

## Change

Failures are collected and reported together, and **no lock is written unless every source resolved** — a partial lock that looks complete is worse than none, since the whole point of the file is that it describes the full set.

```
  UNRESOLVED  civitai:2068000: not found (deleted upstream, or the version id is wrong)
  UNRESOLVED  hf:does-not-exist-xyz/nope@main/nope.safetensors: not found, or gated and no token
  UNRESOLVED  https://example.com/thing.safetensors: a direct URL needs `sha256` in the manifest

3 of 4 sources did not resolve:
  …
No lock written. Fix the manifest and re-run — every failure above is
reported in this one pass, so this should not need repeating.
```

## The trigger was real

`civitai:2068000` — flux1-krea-dev, 23.8 GB — returns **HTTP 404 "Model not found"**. The version was deleted upstream and it was that file's only recorded source. Precisely the finding a reproduction check exists to surface, and it shouldn't cost the other 160 files their resolution.

## Error text names causes, not symptoms

A Civitai 404 now says *"deleted upstream, or the version id is wrong"*; a missing HF file says *"not found, or gated and no token"*. The gated case is common enough to be worth naming — `black-forest-labs` repos are `gated: auto`, and the unauthenticated response is a bare 401 that reads like a missing file.

## Selftest

CI feeds a manifest with three distinct failure modes and requires all three in one report, plus no lock on disk.