### PR TITLE
fix(resolve): authenticate to HuggingFace, encode URL paths, extract the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
           | tar -xJ --strip-components=1 -C /usr/local/bin shellcheck-v0.10.0/shellcheck
         shellcheck --version
-        shellcheck --severity=style --shell=sh services/fetch/*.sh
+        shellcheck --severity=style --shell=sh -x services/fetch/*.sh services/fetch/tests/*.sh
 
     - name: Validate the manifest and the lock against their schemas
       run: |
@@ -94,75 +94,13 @@ jobs:
       # resolve.sh run, like any other diff.
       run: sh services/fetch/check-lock.sh comfy.yaml comfy-lock.yaml
 
-    - name: Selftest — the consistency gate still fails on a real edit
-      # A gate that cannot fail is not a gate. An earlier version of the gate
-      # this replaced reported PASS against four injected faults because its
-      # comparison silently produced two empty files.
-      run: |
-        set -u
-        yq -i 'del(.models[0].hashes)' comfy-lock.yaml
-        if sh services/fetch/check-lock.sh comfy.yaml comfy-lock.yaml; then
-          echo "SELFTEST FAILED: an unhashed lock entry was accepted"
-          exit 1
-        fi
-        git checkout -- comfy-lock.yaml
-        yq -i 'del(.models[0])' comfy.yaml
-        if sh services/fetch/check-lock.sh comfy.yaml comfy-lock.yaml; then
-          echo "SELFTEST FAILED: a lock entry with no manifest declaration was accepted"
-          exit 1
-        fi
-        git checkout -- comfy.yaml
-        yq -i '.profiles.broken = ["no-such-capability"]' comfy.yaml
-        if sh services/fetch/check-lock.sh comfy.yaml comfy-lock.yaml; then
-          echo "SELFTEST FAILED: a profile naming an unknown capability was accepted"
-          exit 1
-        fi
-        git checkout -- comfy.yaml
-        yq -i '.profiles.a = ["b"] | .profiles.b = ["a"]' comfy.yaml
-        if sh services/fetch/check-lock.sh comfy.yaml comfy-lock.yaml; then
-          echo "SELFTEST FAILED: a profile cycle was accepted"
-          exit 1
-        fi
-        git checkout -- comfy.yaml
-        echo "selftest ok: rejects an unhashed entry, an undeclared one, a bad profile member, and a cycle"
-
-    - name: Selftest — resolve reports EVERY bad source, in one pass
-      # A manifest of 161 files with one dead source used to resolve nothing and
-      # report a single problem, so finding N broken sources cost N full passes
-      # over the network. This asserts all of them surface at once, and that no
-      # partial lock is written -- one that looks complete is worse than none.
-      run: |
-        set -u
-        cat > /tmp/bad.yaml <<'YAML'
-        name: selftest
-        models:
-          - name: dead-civitai
-            files:
-              - source: civitai:2068000
-                as: gone.safetensors
-                install: models/unet/
-          - name: bad-repo
-            files:
-              - source: hf:does-not-exist-xyz/nope
-                file: nope.safetensors
-                install: models/loras/
-          - name: url-without-hash
-            files:
-              - source: https://example.com/thing.safetensors
-                install: models/loras/
-        YAML
-        if sh services/fetch/resolve.sh /tmp/bad.yaml > /tmp/bad.lock 2> /tmp/bad.err; then
-          echo "SELFTEST FAILED: resolve succeeded against three broken sources"; exit 1
-        fi
-        if [ -s /tmp/bad.lock ]; then
-          echo "SELFTEST FAILED: a partial lock was written"; cat /tmp/bad.lock; exit 1
-        fi
-        for want in "civitai:2068000" "does-not-exist-xyz" "needs \`sha256\`"; do
-          grep -qF "$want" /tmp/bad.err || {
-            echo "SELFTEST FAILED: '$want' missing from the report"; cat /tmp/bad.err; exit 1
-          }
-        done
-        echo "selftest ok: all three failures reported in one pass, no lock written"
+    - name: Test suite
+      # Cases and fixtures live in services/fetch/tests/, not inline here, so
+      # they run identically on a laptop before pushing and are linted like the
+      # rest of the shell.
+      env:
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      run: sh services/fetch/tests/run.sh
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/services/fetch/dockerfile.comfy.fetch
+++ b/services/fetch/dockerfile.comfy.fetch
@@ -23,7 +23,7 @@ FROM mikefarah/yq:${YQ_VERSION} AS yq
 FROM curlimages/curl:${CURL_VERSION}
 
 COPY --from=yq --chmod=0555 /usr/bin/yq /usr/local/bin/yq
-COPY --chmod=0555 fetch-lock.sh resolve.sh check-lock.sh lib-profiles.sh /usr/local/bin/
+COPY --chmod=0555 fetch-lock.sh resolve.sh check-lock.sh lib-profiles.sh lib-auth.sh /usr/local/bin/
 
 # Prove the three tools the scripts depend on are present and usable at BUILD
 # time. The image is useless without any one of them, and discovering that from

--- a/services/fetch/fetch-lock.sh
+++ b/services/fetch/fetch-lock.sh
@@ -59,37 +59,9 @@ records=0
 # Credentials are resolved by the URL's HOST, from the lock's top-level `auth`
 # map, so no model entry carries an auth field and `models[]` stays exactly
 # comfy-cli's documented shape.
-#
-# The map's values are ${ENV_VAR} references, never literals -- the schema
-# rejects a literal so a token cannot be committed.
-auth_map="$(yq -r '.auth // {} | to_entries[] | .key + " " + .value' "$LOCK" 2>/dev/null || true)"
-
-host_of() { h="${1#*://}"; h="${h%%/*}"; printf '%s' "${h%%:*}"; }
-
-# The env var mapped to a host, or empty.
-var_for_host() {
-  printf '%s\n' "$auth_map" | while read -r host ref; do
-    if [ "$host" = "$1" ]; then
-      ref="${ref#\$\{}"; printf '%s' "${ref%\}}"; return
-    fi
-  done
-}
-
-token_for_url() {
-  v="$(var_for_host "$(host_of "$1")")"
-  [ -n "$v" ] || return 0
-  eval "printf '%s' \"\${$v:-}\""
-}
-
-# Named only to make a failure message accurate: a host with a declared
-# credential whose variable is unset is the likeliest cause of a 401 or of an
-# HTML error page failing the hash check.
-missing_cred_for_url() {
-  v="$(var_for_host "$(host_of "$1")")"
-  [ -n "$v" ] || return 0
-  eval "t=\"\${$v:-}\""
-  [ -n "$t" ] || printf '%s' "$v"
-}
+# shellcheck source=services/fetch/lib-auth.sh
+. "$(dirname "$0")/lib-auth.sh"
+auth_load "$LOCK"
 
 hash_of() { sha256sum "$1" | cut -d' ' -f1; }
 

--- a/services/fetch/lib-auth.sh
+++ b/services/fetch/lib-auth.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Host-keyed credential lookup, shared by resolve.sh and fetch-lock.sh.
+#
+# Extracted rather than duplicated: both need to answer "which token, if any,
+# does this URL's host want", and the manifest and the lock carry the same
+# `auth` map. Two copies would drift.
+#
+# Sourced, not executed. Call auth_load <file> once, then token_for_url <url>.
+
+# The map's values are ${ENV_VAR} references, never literals -- the schema
+# rejects a literal so a token cannot be committed.
+auth_load() { _auth_map="$(yq -r '.auth // {} | to_entries[] | .key + " " + .value' "$1" 2>/dev/null || true)"; }
+
+host_of() { _h="${1#*://}"; _h="${_h%%/*}"; printf '%s' "${_h%%:*}"; }
+
+# The env var mapped to a host, or empty.
+var_for_host() {
+  printf '%s\n' "${_auth_map:-}" | while read -r _host _ref; do
+    if [ "$_host" = "$1" ]; then
+      _ref="${_ref#\$\{}"; printf '%s' "${_ref%\}}"; return
+    fi
+  done
+}
+
+token_for_url() {
+  _v="$(var_for_host "$(host_of "$1")")"
+  [ -n "$_v" ] || return 0
+  eval "printf '%s' \"\${$_v:-}\""
+}
+
+# Named only to make a failure message accurate: a host with a declared
+# credential whose variable is unset is the likeliest cause of a 401.
+missing_cred_for_url() {
+  _v="$(var_for_host "$(host_of "$1")")"
+  [ -n "$_v" ] || return 0
+  eval "_t=\"\${$_v:-}\""
+  [ -n "$_t" ] || printf '%s' "$_v"
+}
+
+# Percent-encode a URL PATH, leaving `/` intact.
+#
+# HuggingFace filenames routinely contain spaces and parentheses -- "Anime v1.3
+# (1).safetensors" is a real one. curl given a raw space produces NO output and
+# no error, so the file reads as absent rather than as a malformed request.
+urlencode_path() {
+  printf '%s' "$1" | awk '
+    BEGIN { for (i = 0; i < 256; i++) ord[sprintf("%c", i)] = i }
+    {
+      out = ""
+      n = split($0, ch, "")
+      for (i = 1; i <= n; i++) {
+        c = ch[i]
+        if (c ~ /[A-Za-z0-9._~\/-]/) out = out c
+        else out = out sprintf("%%%02X", ord[c])
+      }
+      printf "%s", out
+    }'
+}

--- a/services/fetch/resolve.sh
+++ b/services/fetch/resolve.sh
@@ -46,6 +46,8 @@ UA="comfyui-fetch/1.0 (+https://github.com/pixeloven/ComfyUI-Docker)"
 
 # shellcheck source=services/fetch/lib-profiles.sh
 . "$(dirname "$0")/lib-profiles.sh"
+# shellcheck source=services/fetch/lib-auth.sh
+. "$(dirname "$0")/lib-auth.sh"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -85,7 +87,9 @@ if [ -n "$PROFILE" ]; then
     declared=$((declared + n))
   done
 else
-  declared="$(yq -r '[.models[].files[]] | length' "$MANIFEST")"
+  auth_load "$MANIFEST"
+
+declared="$(yq -r '[.models[].files[]] | length' "$MANIFEST")"
 fi
 records=0
 failures=0
@@ -102,7 +106,14 @@ hf_head() {  # <repo> <revision> <file>  -> commit<TAB>sha256
   # NOT -sIL. `x-linked-etag` is the sha256 only on the FIRST hop; following the
   # redirect returns the CDN's Xet content-address, a different and equally
   # plausible-looking 64-hex value.
-  curl -sI -A "$UA" "https://huggingface.co/$1/resolve/$2/$3" \
+  #
+  # Authenticated when the manifest maps huggingface.co to a variable that is
+  # set. Gated repos -- black-forest-labs publishes as `gated: auto` -- answer
+  # 401 without it, which is indistinguishable from a missing file.
+  _u="https://huggingface.co/$1/resolve/$2/$(urlencode_path "$3")"
+  _t="$(token_for_url "$_u")"
+  if [ -n "$_t" ]; then set -- -H "Authorization: Bearer $_t"; else set --; fi
+  curl -sI -A "$UA" "$@" "$_u" \
     | tr -d '\r' \
     | awk 'BEGIN{IGNORECASE=1}
            /^x-repo-commit:/ {c=$2}
@@ -136,11 +147,21 @@ while read -r marker; do
       repo="${source#hf:}"
       if [ -z "$file" ]; then fail "$source: hf source needs \`file\`"; continue; fi
       got="$(hf_head "$repo" "$revision" "$file")"
-      if [ -z "$got" ]; then fail "hf:$repo@$revision/$file: not found, or gated and no token"; continue; fi
+      if [ -z "$got" ]; then
+        _m="$(missing_cred_for_url "https://huggingface.co/")"
+        if [ -n "$_m" ]; then
+          fail "hf:$repo@$revision/$file: not found, or gated (\$$_m is not set)"
+        else
+          fail "hf:$repo@$revision/$file: not found, or you lack access to a gated repo"
+        fi
+        continue
+      fi
       commit="$(printf '%s' "$got" | cut -f1)"
       sha="$(printf '%s' "$got" | cut -f2)"
       # The lock pins the COMMIT, never the moving ref it was resolved from.
-      url="https://huggingface.co/$repo/resolve/$commit/$file"
+      # Encoded, so a filename with spaces survives into the lock and the
+      # fetcher does not have to re-derive it.
+      url="https://huggingface.co/$repo/resolve/$commit/$(urlencode_path "$file")"
       base="$(basename "$file")"
       ;;
     civitai:*)

--- a/services/fetch/tests/fixtures/lock-good.yaml
+++ b/services/fetch/tests/fixtures/lock-good.yaml
@@ -1,0 +1,9 @@
+models:
+  - model: anime6b.pth
+    url: https://huggingface.co/ximso/RealESRGAN_x4plus_anime_6B/resolve/main/RealESRGAN_x4plus_anime_6B.pth
+    paths:
+      - path: models/upscale_models/anime6b.pth
+    hashes:
+      - hash: f872d837d3c90ed2e05227bed711af5671a6fd1c9f7d7e91c911a61f155e99da
+        type: SHA256
+    type: upscale_model

--- a/services/fetch/tests/fixtures/lock-no-hash.yaml
+++ b/services/fetch/tests/fixtures/lock-no-hash.yaml
@@ -1,0 +1,6 @@
+models:
+  - model: anime6b.pth
+    url: https://huggingface.co/ximso/RealESRGAN_x4plus_anime_6B/resolve/main/RealESRGAN_x4plus_anime_6B.pth
+    paths:
+      - path: models/upscale_models/anime6b.pth
+    type: upscale_model

--- a/services/fetch/tests/fixtures/lock-wrong-hash.yaml
+++ b/services/fetch/tests/fixtures/lock-wrong-hash.yaml
@@ -1,0 +1,9 @@
+models:
+  - model: anime6b.pth
+    url: https://huggingface.co/ximso/RealESRGAN_x4plus_anime_6B/resolve/main/RealESRGAN_x4plus_anime_6B.pth
+    paths:
+      - path: models/upscale_models/anime6b.pth
+    hashes:
+      - hash: 0000000000000000000000000000000000000000000000000000000000000000
+        type: SHA256
+    type: upscale_model

--- a/services/fetch/tests/fixtures/manifest-awkward-filename.yaml
+++ b/services/fetch/tests/fixtures/manifest-awkward-filename.yaml
@@ -1,0 +1,10 @@
+# Spaces and parentheses in an upstream filename. curl given a raw space returns
+# NO output and no error, so the file reads as absent rather than as a malformed
+# request -- the path must be percent-encoded.
+name: awkward-filename
+models:
+  - name: spaced
+    files:
+      - source: hf:thisisdom4/Dramatic_Lighting_Slider
+        file: Dramatic Lighting Slider.safetensors
+        install: models/loras/

--- a/services/fetch/tests/fixtures/manifest-broken-sources.yaml
+++ b/services/fetch/tests/fixtures/manifest-broken-sources.yaml
@@ -1,0 +1,18 @@
+# Three distinct failure modes at once. resolve.sh must report ALL of them in a
+# single pass and write no lock.
+name: broken-sources
+models:
+  - name: dead-civitai
+    files:
+      - source: civitai:2068000        # 404 — version deleted upstream
+        as: gone.safetensors
+        install: models/unet/
+  - name: missing-repo
+    files:
+      - source: hf:does-not-exist-xyz/nope
+        file: nope.safetensors
+        install: models/loras/
+  - name: url-without-hash
+    files:
+      - source: https://example.com/thing.safetensors
+        install: models/loras/

--- a/services/fetch/tests/fixtures/manifest-for-lock-good.yaml
+++ b/services/fetch/tests/fixtures/manifest-for-lock-good.yaml
@@ -1,0 +1,9 @@
+name: lock-good
+models:
+  - name: upscaler
+    files:
+      - source: hf:ximso/RealESRGAN_x4plus_anime_6B
+        file: RealESRGAN_x4plus_anime_6B.pth
+        as: anime6b.pth
+        install: models/upscale_models/
+        type: upscale_model

--- a/services/fetch/tests/fixtures/manifest-profile-cycle.yaml
+++ b/services/fetch/tests/fixtures/manifest-profile-cycle.yaml
@@ -1,0 +1,12 @@
+# `a -> b -> a`. A self-reference check would miss this, which is why detection
+# is by bounded expansion.
+name: profile-cycle
+models:
+  - name: real
+    files:
+      - source: hf:madebyollin/taesd
+        file: taesd_decoder.safetensors
+        install: models/vae_approx/
+profiles:
+  a: [b]
+  b: [a]

--- a/services/fetch/tests/fixtures/manifest-profile-unknown-member.yaml
+++ b/services/fetch/tests/fixtures/manifest-profile-unknown-member.yaml
@@ -1,0 +1,9 @@
+name: unknown-member
+models:
+  - name: real
+    files:
+      - source: hf:madebyollin/taesd
+        file: taesd_decoder.safetensors
+        install: models/vae_approx/
+profiles:
+  broken: [real, no-such-capability]

--- a/services/fetch/tests/run.sh
+++ b/services/fetch/tests/run.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# Test suite for the fetch tooling. Runs identically locally and in CI:
+#
+#   sh services/fetch/tests/run.sh
+#
+# Cases live here with their fixtures, not inline in a workflow file, so they
+# can be run before pushing, linted by shellcheck like everything else, and
+# extended without editing CI.
+#
+# Network is required: these assert against real hosts on purpose. A resolver
+# whose tests all mock HTTP would not have caught either of the two bugs that
+# prompted this suite -- missing HuggingFace auth, and unencoded spaces in a
+# URL -- because both are about what the real service does with a real request.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BIN="$(cd "$HERE/.." && pwd)"
+FIX="$HERE/fixtures"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0; fail=0
+
+ok()   { pass=$((pass + 1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail + 1)); printf '  FAIL %s\n' "$1"; if [ -n "${2:-}" ]; then sed 's/^/         /' "$2"; fi; }
+
+# --- resolve: every bad source is reported, in one pass, with no lock ---------
+t_resolve_reports_all() {
+  name="resolve reports every bad source and writes no lock"
+  if sh "$BIN/resolve.sh" "$FIX/manifest-broken-sources.yaml" > "$WORK/o" 2> "$WORK/e"; then
+    bad "$name (succeeded against three broken sources)" "$WORK/e"; return
+  fi
+  [ -s "$WORK/o" ] && { bad "$name (wrote a partial lock)" "$WORK/o"; return; }
+  # shellcheck disable=SC2016  # literal backticks in the expected message.
+  for want in 'civitai:2068000' 'does-not-exist-xyz' 'needs `sha256`'; do
+    grep -qF "$want" "$WORK/e" || { bad "$name (missing '$want')" "$WORK/e"; return; }
+  done
+  ok "$name"
+}
+
+# --- resolve: a filename with spaces resolves ---------------------------------
+# Regression. curl given a raw space produces no output and no error, so the
+# file read as absent and the failure named the wrong cause.
+t_resolve_encodes_paths() {
+  name="resolve percent-encodes a filename containing spaces"
+  if sh "$BIN/resolve.sh" "$FIX/manifest-awkward-filename.yaml" > "$WORK/o2" 2> "$WORK/e2"; then
+    if grep -q '^  - model:' "$WORK/o2"; then ok "$name"; else bad "$name (no model emitted)" "$WORK/o2"; fi
+  else
+    bad "$name" "$WORK/e2"
+  fi
+}
+
+# --- resolve: gated repos need the auth map -----------------------------------
+# Skipped rather than failed when no token is configured: the assertion is about
+# the code path, and a contributor without HF access should still get a green
+# suite rather than a mystery.
+t_resolve_authenticates() {
+  name="resolve authenticates to HuggingFace for a gated repo"
+  if [ -z "${HF_TOKEN:-}" ]; then printf '  skip %s (HF_TOKEN unset)\n' "$name"; return; fi
+  cat > "$WORK/gated.yaml" <<YAML
+name: gated
+auth:
+  huggingface.co: \${HF_TOKEN}
+models:
+  - name: gated
+    files:
+      - source: hf:black-forest-labs/FLUX.1-Krea-dev
+        file: flux1-krea-dev.safetensors
+        install: models/unet/
+YAML
+  if sh "$BIN/resolve.sh" "$WORK/gated.yaml" > "$WORK/o3" 2> "$WORK/e3"; then
+    if grep -q 'f6315581b7cddd450b9aba72b4e9ccf8b6580dc1a6b9538aff43ee26a1a3b6c2' "$WORK/o3"; then
+      ok "$name"
+    else
+      bad "$name (resolved, but not to the expected hash)" "$WORK/o3"
+    fi
+  else
+    bad "$name" "$WORK/e3"
+  fi
+}
+
+# --- check-lock: profiles ------------------------------------------------------
+t_check_rejects_unknown_member() {
+  name="check-lock rejects a profile naming an unknown capability"
+  if sh "$BIN/check-lock.sh" "$FIX/manifest-profile-unknown-member.yaml" "$FIX/lock-good.yaml" > "$WORK/o4" 2>&1; then
+    bad "$name" "$WORK/o4"
+  else
+    if grep -q 'BAD PROFILE' "$WORK/o4"; then ok "$name"; else bad "$name (failed for another reason)" "$WORK/o4"; fi
+  fi
+}
+
+t_check_rejects_cycle() {
+  name="check-lock rejects a profile cycle (a -> b -> a)"
+  if sh "$BIN/check-lock.sh" "$FIX/manifest-profile-cycle.yaml" "$FIX/lock-good.yaml" > "$WORK/o5" 2>&1; then
+    bad "$name" "$WORK/o5"
+  else
+    if grep -q 'cycle' "$WORK/o5"; then ok "$name"; else bad "$name (failed for another reason)" "$WORK/o5"; fi
+  fi
+}
+
+t_check_rejects_unhashed_entry() {
+  name="check-lock rejects a lock entry with no SHA256"
+  if sh "$BIN/check-lock.sh" "$FIX/manifest-for-lock-good.yaml" "$FIX/lock-no-hash.yaml" > "$WORK/o6" 2>&1; then
+    bad "$name" "$WORK/o6"
+  else
+    if grep -q 'NO SHA256' "$WORK/o6"; then ok "$name"; else bad "$name (failed for another reason)" "$WORK/o6"; fi
+  fi
+}
+
+t_check_accepts_agreeing_pair() {
+  name="check-lock accepts a manifest and lock that agree"
+  if sh "$BIN/check-lock.sh" "$FIX/manifest-for-lock-good.yaml" "$FIX/lock-good.yaml" > "$WORK/o7" 2>&1; then
+    ok "$name"
+  else
+    bad "$name" "$WORK/o7"
+  fi
+}
+
+echo "fetch tooling tests"
+t_resolve_reports_all
+t_resolve_encodes_paths
+t_resolve_authenticates
+t_check_rejects_unknown_member
+t_check_rejects_cycle
+t_check_rejects_unhashed_entry
+t_check_accepts_agreeing_pair
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" = 0 ]


### PR DESCRIPTION
Three things, all surfaced by resolving a real 161-file manifest — and one of them is your review comment on #58.

## 1. `resolve.sh` never authenticated to HuggingFace

`hf_head` sent no `Authorization` header. A gated repo answers **401**, which the resolver reported as *"not found"* — indistinguishable from a missing file.

```
no token : HTTP/2 401
token    : HTTP/2 302
```

`black-forest-labs` publishes as `gated: auto`, and `flux1-krea-dev` (23.8 GB) is **only** reachable this way now that its Civitai version has been deleted upstream. So this wasn't theoretical — it blocked a real recovery.

The auth lookup moved to `lib-auth.sh`, shared with `fetch-lock.sh` rather than copied (matching the `lib-profiles.sh` precedent).

## 2. URL paths were not encoded

HuggingFace filenames routinely contain spaces and parentheses — `Anime v1.3 (1).safetensors` is a real one in use here. **curl given a raw space produces no output and no error**, so the file read as absent and the failure named the wrong cause:

```
raw space  :                              # nothing at all
encoded    : HTTP/2 302
```

Paths are percent-encoded now, and the encoded form is what lands in the lock so the fetcher doesn't have to re-derive it.

## 3. Tests out of the workflow file — your #58 comment

Agreed, and I was one commit from adding a fourth inline heredoc. `services/fetch/tests/` now holds fixtures and a runner that works identically on a laptop and in CI:

```sh
sh services/fetch/tests/run.sh
```

```
  ok   resolve reports every bad source and writes no lock
  ok   resolve percent-encodes a filename containing spaces
  ok   resolve authenticates to HuggingFace for a gated repo
  ok   check-lock rejects a profile naming an unknown capability
  ok   check-lock rejects a profile cycle (a -> b -> a)
  ok   check-lock rejects a lock entry with no SHA256
  ok   check-lock accepts a manifest and lock that agree
```

The gated case **skips** rather than fails without `HF_TOKEN`, so a contributor without access gets a green suite instead of a mystery. Shellcheck now covers `tests/` too — which immediately caught the suite using the same `A && B || C` footgun these tests exist to catch elsewhere.

**Deliberately not mocked.** Neither bug above would have been caught by a suite that mocks HTTP: both are about what a real host does with a real request.

## On your CLI point

Worth taking seriously and I've replied on the thread — short version: I think the split is between the *runtime* fetcher (stays small and dependency-free, it ships in an image) and the *authoring* tools, where the bug density has actually been. Not something to decide inside this PR.