### PR TITLE
fix(resolve): load credentials unconditionally, not only without --profile

### DIFF
--- a/services/fetch/resolve.sh
+++ b/services/fetch/resolve.sh
@@ -80,6 +80,12 @@ in_selection() {
   case " $selected " in *" $1 "*) return 0 ;; *) return 1 ;; esac
 }
 
+# Unconditionally, and before any request. Placed inside the else branch below
+# it would load credentials only when NO --profile was given -- which is the
+# path nobody uses, and the failure is silent: gated repos simply report as
+# "not found".
+auth_load "$MANIFEST"
+
 if [ -n "$PROFILE" ]; then
   declared=0
   for m in $selected; do

--- a/services/fetch/tests/run.sh
+++ b/services/fetch/tests/run.sh
@@ -80,6 +80,38 @@ YAML
   fi
 }
 
+# --- resolve: the same, but through --profile ---------------------------------
+# Regression. `auth_load` was placed in the branch taken only when no --profile
+# is given, so credentials loaded for the path nobody uses. The case above
+# passed while every real invocation went unauthenticated, and the failure is
+# silent: a gated repo just reports as "not found".
+t_resolve_authenticates_with_profile() {
+  name="resolve authenticates for a gated repo THROUGH --profile"
+  if [ -z "${HF_TOKEN:-}" ]; then printf '  skip %s (HF_TOKEN unset)\n' "$name"; return; fi
+  cat > "$WORK/gatedp.yaml" <<YAML
+name: gated-profile
+auth:
+  huggingface.co: \${HF_TOKEN}
+models:
+  - name: gated
+    files:
+      - source: hf:black-forest-labs/FLUX.1-Krea-dev
+        file: flux1-krea-dev.safetensors
+        install: models/unet/
+profiles:
+  only: [gated]
+YAML
+  if sh "$BIN/resolve.sh" "$WORK/gatedp.yaml" --profile only > "$WORK/o8" 2> "$WORK/e8"; then
+    if grep -q 'f6315581b7cddd450b9aba72b4e9ccf8b6580dc1a6b9538aff43ee26a1a3b6c2' "$WORK/o8"; then
+      ok "$name"
+    else
+      bad "$name (resolved, but not to the expected hash)" "$WORK/o8"
+    fi
+  else
+    bad "$name" "$WORK/e8"
+  fi
+}
+
 # --- check-lock: profiles ------------------------------------------------------
 t_check_rejects_unknown_member() {
   name="check-lock rejects a profile naming an unknown capability"
@@ -121,6 +153,7 @@ echo "fetch tooling tests"
 t_resolve_reports_all
 t_resolve_encodes_paths
 t_resolve_authenticates
+t_resolve_authenticates_with_profile
 t_check_rejects_unknown_member
 t_check_rejects_cycle
 t_check_rejects_unhashed_entry


### PR DESCRIPTION
`auth_load` sat inside the branch taken only when **no** `--profile` is given, so credentials loaded for the path nobody uses. Every real invocation went unauthenticated and gated repos reported as *"not found"* — the same silent failure #59 fixed, reintroduced one line away from the fix.

```sh
if [ -n "$PROFILE" ]; then
  declared=0
  …
else
  auth_load "$MANIFEST"     # ← only here
  declared=…
fi
```

## The test didn't catch it, which is the more useful finding

The gated case added in #59 doesn't pass `--profile`, so it exercised the one code path where credentials *did* load. **It passed while every real call was broken.**

Found by running the actual 161-file manifest — 2 of 161 unresolved, both gated Black Forest Labs repos, with a token present and working when tested by hand.

This adds the same assertion through `--profile`. A test that stays green while the feature is broken is worse than no test, because it converts an outage into a lie.

8 cases now, all passing.