### PR TITLE
feat(resolve): --from-lock, deriving profile locks without re-resolving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,22 +64,23 @@ jobs:
       # literally -- so a gate on a different version is a gate on different
       # behaviour.
       run: |
-        sudo curl -fsSL --retry 3 -o /usr/local/bin/yq \
+        sudo curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /usr/local/bin/yq \
           https://github.com/mikefarah/yq/releases/download/v4.47.1/yq_linux_amd64
         sudo chmod 0555 /usr/local/bin/yq
         yq --version
 
     - name: Shellcheck the fetch scripts
-      # Pinned, and --severity=style so CI is not quietly stricter or laxer than
-      # a contributor's local shellcheck. A distro-provided version silently
-      # differing from the author's is how an SC2015 reached CI having passed
-      # locally.
+      # The published image rather than a release tarball: same pinned binary a
+      # contributor runs locally, and one less network fetch to fail. This step
+      # went red once on `curl: (35) Connection reset by peer` with nothing
+      # wrong in the tree.
+      #
+      # --severity=style so CI is not quietly stricter or laxer than a local
+      # run; a distro-provided shellcheck differing from the author's is how an
+      # SC2015 reached CI having passed locally.
       run: |
-        curl -fsSL --retry 3 \
-          https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
-          | tar -xJ --strip-components=1 -C /usr/local/bin shellcheck-v0.10.0/shellcheck
-        shellcheck --version
-        shellcheck --severity=style --shell=sh -x services/fetch/*.sh services/fetch/tests/*.sh
+        docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:v0.10.0 \
+          --severity=style --shell=sh -x services/fetch/*.sh services/fetch/tests/*.sh
 
     - name: Validate the manifest and the lock against their schemas
       run: |
@@ -207,7 +208,7 @@ jobs:
       working-directory: examples/core-gpu
       run: |
         set -eu
-        sudo curl -fsSL --retry 3 -o /usr/local/bin/yq \
+        sudo curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /usr/local/bin/yq \
           https://github.com/mikefarah/yq/releases/download/v4.47.1/yq_linux_amd64
         sudo chmod 0555 /usr/local/bin/yq
 

--- a/services/fetch/README.md
+++ b/services/fetch/README.md
@@ -68,12 +68,24 @@ profiles:
 ```
 
 ```sh
-resolve.sh comfy.yaml --profile image > locks/image.yaml
-resolve.sh comfy.yaml --profile video > locks/video.yaml
+# Resolve the full set ONCE, then derive each profile from it.
+resolve.sh comfy.yaml                                       > locks/everything.yaml
+resolve.sh comfy.yaml --profile image --from-lock locks/everything.yaml > locks/image.yaml
+resolve.sh comfy.yaml --profile video --from-lock locks/everything.yaml > locks/video.yaml
 
 fetch-lock.sh locks/image.yaml /workspace --apply
 fetch-lock.sh locks/video.yaml /workspace --apply   # shared files already correct, skipped
 ```
+
+`--from-lock` selects from an existing lock instead of resolving. Producing N
+profile locks otherwise means N network passes over heavily overlapping files —
+and, worse, locks resolved minutes apart can legitimately pin *different*
+commits if a moving `revision:` advanced between runs. Deriving them from one
+parent makes every profile pin identical commits by construction, and each
+derived lock is a **strict subset** of that parent, copied verbatim.
+
+If the parent does not hold a file the profile selects, it is stale: the command
+says so and writes nothing, rather than emitting a lock that is quietly short.
 
 Profiles compose by **set union**, not inheritance — no resolution order, no
 overrides, no diamonds. A model shared between two profiles is defined once and

--- a/services/fetch/resolve.sh
+++ b/services/fetch/resolve.sh
@@ -14,11 +14,18 @@
 # returns hashes in headers, and Civitai's model-versions endpoint is public.
 # Tokens are needed to FETCH, not to resolve.
 #
-# Usage: resolve.sh <comfy.yaml> [--profile <name>]
+# Usage: resolve.sh <comfy.yaml> [--profile <name>] [--from-lock <lock.yaml>]
 # Writes a `models:` document to stdout. Redirect it into the lock.
 #
 # Without --profile every model is resolved. With one, only the capabilities
 # that profile names -- expanded transitively, since a profile may name another.
+#
+# --from-lock SELECTS from an existing lock instead of resolving. Producing N
+# profile locks otherwise means N network passes over heavily overlapping files,
+# and -- worse -- locks resolved minutes apart can legitimately pin DIFFERENT
+# commits if a moving ref advanced between runs. Deriving them all from one
+# parent makes every profile pin identical commits by construction, and the
+# result is a strict subset of that parent.
 
 set -eu
 
@@ -36,11 +43,21 @@ MANIFEST="${1:?usage: resolve.sh <comfy.yaml> [--profile <name>]}"
 [ -f "$MANIFEST" ] || { echo "no such manifest: $MANIFEST" >&2; exit 2; }
 
 PROFILE=""
-case "${2:-}" in
-  --profile) PROFILE="${3:?--profile needs a name}" ;;
-  "")        ;;
-  *)         echo "unknown argument: $2" >&2; exit 2 ;;
-esac
+FROM_LOCK=""
+shift
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --profile)   PROFILE="${2:?--profile needs a name}"; shift 2 ;;
+    --from-lock) FROM_LOCK="${2:?--from-lock needs a path}"; shift 2 ;;
+    *)           echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+if [ -n "$FROM_LOCK" ] && [ ! -f "$FROM_LOCK" ]; then
+  echo "no such lock: $FROM_LOCK" >&2; exit 2
+fi
+if [ -n "$FROM_LOCK" ] && [ -z "$PROFILE" ]; then
+  echo "--from-lock needs --profile: without one it would copy the lock verbatim" >&2; exit 2
+fi
 
 UA="comfyui-fetch/1.0 (+https://github.com/pixeloven/ComfyUI-Docker)"
 
@@ -85,6 +102,62 @@ in_selection() {
 # path nobody uses, and the failure is silent: gated repos simply report as
 # "not found".
 auth_load "$MANIFEST"
+
+# --- selection from an existing lock ------------------------------------------
+# No network, no resolution: the parent already holds resolved entries, so this
+# filters it to the paths the profile selects and copies them VERBATIM.
+if [ -n "$FROM_LOCK" ]; then
+  selected="$(expand_profile "$MANIFEST" "$PROFILE")" || exit 2
+  echo "profile $PROFILE selects (from $FROM_LOCK): $selected" >&2
+
+  want="$(mktemp)"; trap 'rm -f "$want"' EXIT
+  for cap in $selected; do
+    NAME="$cap" yq -r '.models[] | select(.name == strenv(NAME)) | .files[] |
+      "models/" + .install[7:] + (.as // (.file // "" | sub(".*/"; "")))' "$MANIFEST" >> "$want"
+  done
+  sort -u -o "$want" "$want"
+
+  n_want="$(wc -l < "$want")"
+  if [ "$n_want" = 0 ]; then
+    echo "profile $PROFILE selects no files" >&2; exit 1
+  fi
+
+  # A path the profile wants that the parent does not hold means the parent is
+  # stale. Emitting a short lock silently would hide that.
+  missing=""
+  while read -r path; do
+    if [ "$(P="$path" yq -r '[.models[] | select((.paths // [])[0].path == strenv(P))] | length' "$FROM_LOCK")" = "0" ]; then
+      missing="${missing}  $path
+"
+    fi
+  done < "$want"
+  if [ -n "$missing" ]; then
+    echo "" >&2
+    echo "these files are selected by $PROFILE but absent from $FROM_LOCK:" >&2
+    printf '%s' "$missing" >&2
+    echo "The parent lock is stale -- re-resolve it before deriving from it." >&2
+    exit 1
+  fi
+
+  # Nothing is written until the parent is known to hold every selected path.
+  # Emitting the auth block first wrote a partial lock on the stale-parent path
+  # -- the same "no partial lock" rule the resolve path already follows.
+  if [ "$(yq -r 'has("auth")' "$FROM_LOCK")" = "true" ]; then
+    yq -o yaml -r '{"auth": .auth}' "$FROM_LOCK"
+  fi
+
+  # One lookup per selected path. Obviously correct beats clever: entries are
+  # copied VERBATIM from the parent, so a derived lock is a strict subset of it
+  # and every profile pins the same commits.
+  echo "models:"
+  while read -r path; do
+    P="$path" yq -o yaml -r \
+      '.models[] | select((.paths // [])[0].path == strenv(P))' "$FROM_LOCK" \
+      | sed '1s/^/  - /; 2,$s/^/    /'
+  done < "$want"
+
+  exit 0
+fi
 
 if [ -n "$PROFILE" ]; then
   declared=0

--- a/services/fetch/resolve.sh
+++ b/services/fetch/resolve.sh
@@ -112,8 +112,12 @@ if [ -n "$FROM_LOCK" ]; then
 
   want="$(mktemp)"; trap 'rm -f "$want"' EXIT
   for cap in $selected; do
+    # Same expression check-lock.sh derives install paths with. `install`
+    # already begins `models/`, so nothing needs prefixing -- an earlier version
+    # prepended and then sliced, which yq 4.47 rejects outright while 4.53
+    # accepts it.
     NAME="$cap" yq -r '.models[] | select(.name == strenv(NAME)) | .files[] |
-      "models/" + .install[7:] + (.as // (.file // "" | sub(".*/"; "")))' "$MANIFEST" >> "$want"
+      .install + (.as // (.file // "" | sub(".*/"; "")))' "$MANIFEST" >> "$want"
   done
   sort -u -o "$want" "$want"
 

--- a/services/fetch/tests/fixtures/lock-stale-parent.yaml
+++ b/services/fetch/tests/fixtures/lock-stale-parent.yaml
@@ -1,0 +1,11 @@
+auth:
+  huggingface.co: ${HF_TOKEN}
+models:
+  - model: taesd_decoder.safetensors
+    url: https://huggingface.co/madebyollin/taesd/resolve/614f76814bbe30edbe2e627ace1c2234c81a2c0e/taesd_decoder.safetensors
+    paths:
+      - path: models/vae_approx/taesd_decoder.safetensors
+    hashes:
+      - hash: f0fb51dd10d41c26612c070fa0b52ea0215a5ff90792134b4971109dd713c019
+        type: SHA256
+    type: vae_approx

--- a/services/fetch/tests/fixtures/lock-two-entries.yaml
+++ b/services/fetch/tests/fixtures/lock-two-entries.yaml
@@ -1,0 +1,19 @@
+auth:
+  huggingface.co: ${HF_TOKEN}
+models:
+  - model: taesd_decoder.safetensors
+    url: https://huggingface.co/madebyollin/taesd/resolve/614f76814bbe30edbe2e627ace1c2234c81a2c0e/taesd_decoder.safetensors
+    paths:
+      - path: models/vae_approx/taesd_decoder.safetensors
+    hashes:
+      - hash: f0fb51dd10d41c26612c070fa0b52ea0215a5ff90792134b4971109dd713c019
+        type: SHA256
+    type: vae_approx
+  - model: taesdxl_decoder.safetensors
+    url: https://huggingface.co/madebyollin/taesdxl/resolve/b20258aaef75ef61e659c1e0f14f251cf0ad153e/taesdxl_decoder.safetensors
+    paths:
+      - path: models/vae_approx/taesdxl_decoder.safetensors
+    hashes:
+      - hash: f6013131e7eb412ef20113f1acc2ea7d3e47e53196ca0530fa65d9b61d814b61
+        type: SHA256
+    type: vae_approx

--- a/services/fetch/tests/fixtures/manifest-two-profiles.yaml
+++ b/services/fetch/tests/fixtures/manifest-two-profiles.yaml
@@ -1,0 +1,15 @@
+name: two-profiles
+models:
+  - name: a
+    files:
+      - source: hf:madebyollin/taesd
+        file: taesd_decoder.safetensors
+        install: models/vae_approx/
+  - name: b
+    files:
+      - source: hf:madebyollin/taesdxl
+        file: taesdxl_decoder.safetensors
+        install: models/vae_approx/
+profiles:
+  just-a: [a]
+  both: [a, b]

--- a/services/fetch/tests/run.sh
+++ b/services/fetch/tests/run.sh
@@ -112,6 +112,44 @@ YAML
   fi
 }
 
+# --- resolve --from-lock: selection without re-resolving -----------------------
+t_from_lock_is_strict_subset() {
+  name="--from-lock copies entries verbatim (strict subset of the parent)"
+  if ! sh "$BIN/resolve.sh" "$FIX/manifest-two-profiles.yaml" --profile just-a \
+        --from-lock "$FIX/lock-two-entries.yaml" > "$WORK/sub" 2> "$WORK/sube"; then
+    bad "$name" "$WORK/sube"; return
+  fi
+  # One entry, and byte-identical to the parent's.
+  if [ "$(grep -c '^  - model:' "$WORK/sub")" != 1 ]; then
+    bad "$name (wrong entry count)" "$WORK/sub"; return
+  fi
+  want="$(P=models/vae_approx/taesd_decoder.safetensors yq -o yaml -r \
+    '.models[] | select((.paths // [])[0].path == strenv(P))' "$FIX/lock-two-entries.yaml")"
+  got="$(P=models/vae_approx/taesd_decoder.safetensors yq -o yaml -r \
+    '.models[] | select((.paths // [])[0].path == strenv(P))' "$WORK/sub")"
+  if [ "$want" = "$got" ]; then ok "$name"; else bad "$name (entry differs from parent)"; fi
+}
+
+t_from_lock_detects_stale_parent() {
+  name="--from-lock refuses a parent missing a selected file"
+  if sh "$BIN/resolve.sh" "$FIX/manifest-two-profiles.yaml" --profile both \
+       --from-lock "$FIX/lock-stale-parent.yaml" > "$WORK/st" 2> "$WORK/ste"; then
+    bad "$name (accepted a stale parent)" "$WORK/st"; return
+  fi
+  if [ -s "$WORK/st" ]; then bad "$name (wrote a partial lock)" "$WORK/st"; return; fi
+  if grep -q 'stale' "$WORK/ste"; then ok "$name"; else bad "$name" "$WORK/ste"; fi
+}
+
+t_from_lock_needs_profile() {
+  name="--from-lock without --profile is rejected"
+  if sh "$BIN/resolve.sh" "$FIX/manifest-two-profiles.yaml" \
+       --from-lock "$FIX/lock-two-entries.yaml" > "$WORK/np" 2> "$WORK/npe"; then
+    bad "$name (accepted)" "$WORK/np"
+  else
+    ok "$name"
+  fi
+}
+
 # --- check-lock: profiles ------------------------------------------------------
 t_check_rejects_unknown_member() {
   name="check-lock rejects a profile naming an unknown capability"
@@ -154,6 +192,9 @@ t_resolve_reports_all
 t_resolve_encodes_paths
 t_resolve_authenticates
 t_resolve_authenticates_with_profile
+t_from_lock_is_strict_subset
+t_from_lock_detects_stale_parent
+t_from_lock_needs_profile
 t_check_rejects_unknown_member
 t_check_rejects_cycle
 t_check_rejects_unhashed_entry


### PR DESCRIPTION
Producing N profile locks meant N network passes over heavily overlapping files. Against a real 161-file manifest with five profiles that's **433 lookups for 161 distinct files**, with Civitai rate limits in the middle.

```sh
resolve.sh comfy.yaml                                        > locks/everything.yaml
resolve.sh comfy.yaml --profile sdxl --from-lock locks/everything.yaml > locks/sdxl.yaml
```

## The correctness argument is stronger than the cost one

Locks resolved minutes apart can legitimately pin **different commits** — a moving `revision:` is *supposed* to advance. So independently-resolved profiles could disagree about what "the same file" is, and nothing would flag it. Deriving them from one parent makes every profile pin identical commits **by construction**.

Entries are copied verbatim, so a derived lock is a **strict subset** of its parent. Verified against the real data:

| profile | entries | |
|---|---|---|
| common | 37 | all verbatim |
| sdxl | 128 | all verbatim |
| flux | 69 | all verbatim |
| qwen | 38 | all verbatim |
| everything | 161 | parent |

All five schema-valid; the four derived ones cost **zero** network calls.

## Stale parents

If the parent doesn't hold a file the profile selects, it's stale — the command names the missing files and writes nothing, rather than emitting a lock that's quietly short.

Its first version emitted the `auth` block *before* that check, so it wrote a partial lock: the same "no partial lock" rule the resolve path already follows, broken in the new path. **Caught by the test written for it** — which is the first time in this series a test found the bug before the real data did.

`--from-lock` without `--profile` is rejected; it would just copy the lock.

11 test cases now, all passing.