### PR TITLE
ci: publish the fetch image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,71 @@ jobs:
         grep -q '^present:     2' /tmp/second.log || { echo "NOT IDEMPOTENT"; cat /tmp/second.log; exit 1; }
         grep -q '^fetched:     0' /tmp/second.log || { echo "REFETCHED"; cat /tmp/second.log; exit 1; }
 
+  publish-fetch:
+    name: publish the fetch image
+    runs-on: ubuntu-latest
+    needs: [validate-examples, test-bake-targets, validate-models, end-to-end]
+    env:
+      REGISTRY: ghcr.io
+    steps:
+    - uses: actions/checkout@v7
+
+    # No free-disk-space or prune step: this image is ~48 MB, not a CUDA stack.
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      run: |
+        echo "commit_sha=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+        echo "repository_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')" >> $GITHUB_OUTPUT
+
+    - name: Build and push
+      id: build
+      uses: docker/bake-action@v7
+      with:
+        files: docker-bake.hcl
+        targets: fetch
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        set: |
+          *.cache-from=type=gha
+          *.cache-to=type=gha,mode=max
+        provenance: false
+        sbom: false
+      env:
+        REGISTRY_URL: ghcr.io/${{ steps.meta.outputs.repository_lower }}/
+        IMAGE_LABEL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.meta.outputs.commit_sha || 'latest' }}
+        PUBLISH_LATEST: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+    # Consumers pin by digest, so the digest has to be findable without digging
+    # through logs. Harmony pins this one in a Job manifest.
+    - name: Publish the digest to the job summary
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        {
+          echo "### fetch image"
+          echo ""
+          echo "- tag: \`ghcr.io/${{ steps.meta.outputs.repository_lower }}/fetch:${{ steps.meta.outputs.commit_sha }}\`"
+          echo ""
+          echo "Pin consumers by digest:"
+          echo ""
+          echo '```'
+          docker buildx imagetools inspect \
+            "ghcr.io/${{ steps.meta.outputs.repository_lower }}/fetch:${{ steps.meta.outputs.commit_sha }}" \
+            --format '{{println .Manifest.Digest}}' \
+            | sed "s|^|ghcr.io/${{ steps.meta.outputs.repository_lower }}/fetch@|"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
   build-cuda:
     runs-on: ubuntu-latest
     needs: [validate-examples, test-bake-targets, validate-models, end-to-end]

--- a/services/fetch/README.md
+++ b/services/fetch/README.md
@@ -119,6 +119,23 @@ check-lock.sh comfy.yaml comfy-lock.yaml       # offline; what CI runs
 Paths in the lock begin `models/`, so the fetcher's second argument is the
 **ComfyUI root**, not the models directory.
 
+### Pinning it
+
+Every push to `main` publishes the image and prints its digest to the workflow
+run summary:
+
+```
+ghcr.io/pixeloven/comfyui/fetch:<commit-sha>
+ghcr.io/pixeloven/comfyui/fetch:latest
+```
+
+**Pin by digest, not by tag.** `latest` moves, and a fetcher that changes under a
+deployment is the opposite of what a lock is for:
+
+```
+ghcr.io/pixeloven/comfyui/fetch@sha256:...
+```
+
 Docker:
 
 ```sh


### PR DESCRIPTION
**The fetch image has never reached a registry.**

The bake target exists and CI builds it twice — in `validate-models` and in `end-to-end` — but both with `push: false`. The publishing jobs build `cuda` / `cuda-arch` / `cpu` / `rocm` / `xpu` and never `fetch`.

## Why nothing caught it

- `test-bake-targets` asserts the target **exists**
- `end-to-end` proves it **works**
- Neither says anything about whether it can be **pulled**

Found by a consumer trying to pin it: the only digest available was a local bake build. Pinning that would have been exactly the stale-digest hazard pinning exists to prevent — an image reference that resolves on one machine and nowhere else.

## Change

Mirrors `build-cpu`, minus the free-disk-space and prune steps — this image is ~48 MB, not a CUDA stack. Pushes only on `main`, gated identically to the others, and depends on the same four validation jobs.

The digest is written to the run summary, since consumers pin by digest and shouldn't have to dig through build logs:

```
ghcr.io/pixeloven/comfyui/fetch@sha256:…
```

README now says to pin by digest rather than `latest` — a fetcher that changes under a deployment is the opposite of what a lock is for.