### PR TITLE
ci: only build what changed, and stop building superseded commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,49 @@ on:
         type: boolean
         default: false
 
+# A new push to a PR makes the previous run obsolete, so cancel it. NEVER on
+# main: a rapid second merge would cancel the first one's image publish, leaving
+# no image for a commit consumers may already pin by sha.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Which parts of the repo a change touches. The expensive image builds are
+  # ~60 of the ~62 minutes a full run costs, and most changes cannot affect
+  # them: every one of the fetch-tooling PRs built the CUDA and XPU stacks for
+  # nothing.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.filter.outputs.images }}
+      fetch: ${{ steps.filter.outputs.fetch }}
+      examples: ${{ steps.filter.outputs.examples }}
+    steps:
+    - uses: actions/checkout@v7
+    # Pinned by SHA, like every other third-party action here. It is used rather
+    # than a hand-rolled `git diff` because the awkward cases -- PR merge-base,
+    # first push to a branch, force-push -- are exactly where a hand-rolled
+    # version silently matches nothing and SKIPS a build that should have run.
+    - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+      id: filter
+      with:
+        filters: |
+          images:
+            - 'services/comfy/**'
+            - 'services/runtime/**'
+            - 'services/mcp/**'
+            - 'docker-bake.hcl'
+            - '.github/workflows/ci.yml'
+          fetch:
+            - 'services/fetch/**'
+            - 'comfy.yaml'
+            - 'comfy-lock.yaml'
+            - 'locks/**'
+            - 'schemas/**'
+          examples:
+            - 'examples/**'
+
   validate-examples:
     runs-on: ubuntu-latest
     steps:
@@ -247,6 +289,7 @@ jobs:
   publish-fetch:
     name: publish the fetch image
     runs-on: ubuntu-latest
+    # Keeps the full gate: it publishes an artifact consumers pin by digest.
     needs: [validate-examples, test-bake-targets, validate-models, end-to-end]
     env:
       REGISTRY: ghcr.io
@@ -311,7 +354,8 @@ jobs:
 
   build-cuda:
     runs-on: ubuntu-latest
-    needs: [validate-examples, test-bake-targets, validate-models, end-to-end]
+    needs: [changes, test-bake-targets]
+    if: github.event_name == 'push' || needs.changes.outputs.images == 'true'
     env:
       REGISTRY: ghcr.io
     steps:
@@ -446,7 +490,8 @@ jobs:
 
   build-cpu:
     runs-on: ubuntu-latest
-    needs: [validate-examples, test-bake-targets, validate-models, end-to-end]
+    needs: [changes, test-bake-targets]
+    if: github.event_name == 'push' || needs.changes.outputs.images == 'true'
     env:
       REGISTRY: ghcr.io
     steps:
@@ -513,7 +558,8 @@ jobs:
 
   build-linux-accelerators:
     runs-on: ubuntu-latest
-    needs: [validate-examples, test-bake-targets, validate-models, end-to-end]
+    needs: [changes, test-bake-targets]
+    if: github.event_name == 'push' || needs.changes.outputs.images == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A full run is **~62 minutes**, of which **~60 is the ComfyUI image builds**:

| min | job |
|---|---|
| 22.2 | build-linux-accelerators (xpu) |
| 19.4 | build-cuda |
| 8.7 | build-cpu |
| 7.3 | build-cuda-arch |
| 2.7 | build-linux-accelerators (rocm) |
| **1.4** | **everything else combined** |

Every fetch-tooling PR merged today built the CUDA and XPU stacks, none of which any of them could affect. Seven PRs — roughly **seven hours** of irrelevant building.

## Four changes

**1. Cancel superseded PR runs.** #63 fired four runs; three were obsolete the moment the next commit landed. Deliberately **not** on `main`: a rapid second merge would cancel the first one's publish, leaving no image for a commit consumers may already pin by sha.

**2. A `changes` job** classifying the diff with `dorny/paths-filter`, pinned by SHA like every other third-party action here. Chosen over a hand-rolled `git diff` because the awkward cases — PR merge-base, first push to a branch, force-push — are exactly where a hand-rolled version silently matches nothing and **skips a build that should have run**. That's the silent-pass shape this repo keeps getting bitten by.

**3. Image builds run always on `main`, on PRs only when image inputs change.** Publishing can never be skipped by a filter — `github.event_name == 'push'` short-circuits the condition.

`ci.yml` is itself in the `images` filter, so a change to how builds are gated still triggers a full build — **including this PR**, which is the point.

**4. Image builds depend only on `test-bake-targets`.** A CUDA build has no relationship to whether a model lock matches its manifest; serialising ~1 min of unrelated validation in front of ~60 min of building buys nothing.

## What it costs now

| change touches | runs | ~time |
|---|---|---|
| `services/fetch/**`, `comfy.yaml`, `locks/**` | validators + e2e + publish | **~1 min** |
| `examples/**` | validators + e2e | **~0.5 min** |
| `services/comfy/**`, `docker-bake.hcl`, `ci.yml` | everything | ~62 min |
| any push to `main` | everything | ~62 min |

## Deliberately unchanged

The cheap validators still run unconditionally on every PR. They cost ~1.4 minutes combined, and skipping a real check to save that would be the wrong trade.