### PR TITLE
fix(ci): actually build the mcp image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,51 @@ jobs:
         IMAGE_VERSION: ${{ needs.context.outputs.image_version }}
         PUBLISH_LATEST: ${{ needs.context.outputs.publish_latest }}
 
+  # The mcp image. bake has declared it since #43 and VERSIONING.md counts it
+  # in the image family -- but no job ever built it, so `mcp:latest` has never
+  # existed and `mcp:0.1.0` failed the first release that went looking for it.
+  #
+  # No free-disk-space step: this is python:3.12-slim plus a git clone, not a
+  # CUDA stack.
+  build-mcp:
+    runs-on: ubuntu-latest
+    needs: [context, test-bake-targets]
+    if: needs.context.outputs.build_images == 'true'
+    env:
+      REGISTRY: ghcr.io
+    steps:
+    - uses: actions/checkout@v7.0.1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4.3.0
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v4.6.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build the mcp image
+      uses: docker/bake-action@v7.3.0
+      with:
+        files: docker-bake.hcl
+        targets: mcp
+        push: ${{ github.event_name == 'push' }}
+        no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        set: |
+          *.cache-from=type=gha
+          *.cache-to=type=gha,mode=max
+        provenance: false
+        sbom: false
+      env:
+        REGISTRY_URL: ${{ needs.context.outputs.registry_url }}
+        IMAGE_LABEL: ${{ needs.context.outputs.image_label }}
+        COMFYUI_VERSION: ${{ needs.context.outputs.comfyui_version }}
+        IMAGE_VERSION: ${{ needs.context.outputs.image_version }}
+        PUBLISH_LATEST: ${{ needs.context.outputs.publish_latest }}
+
   build-cpu:
     runs-on: ubuntu-latest
     needs: [context, test-bake-targets]
@@ -713,7 +758,7 @@ jobs:
   release:
     name: cut the release
     runs-on: ubuntu-latest
-    needs: [context, publish-fetch, build-cuda, build-cuda-arch, build-cpu, build-linux-accelerators]
+    needs: [context, publish-fetch, build-cuda, build-cuda-arch, build-cpu, build-mcp, build-linux-accelerators]
     # A release tag builds one line, so the other line's jobs are `skipped`, not
     # `success` -- hence the explicit failure test rather than the default
     # all-of-needs-succeeded.


### PR DESCRIPTION
`v0.1.0` was cut. All twelve image builds succeeded, `publish the fetch image` correctly skipped — and then the release job failed, exactly as intended.

## What it caught

The release job enumerates the tags `bake` says a version publishes, then resolves each digest:

```
ghcr.io/pixeloven/comfyui/complete@sha256:59ed8dd7...   6 resolved
ghcr.io/pixeloven/comfyui/core@sha256:ebed102a...       4 resolved
ERROR: ghcr.io/pixeloven/comfyui/mcp:0.1.0: not found
```

`bake` has declared an `mcp` target since #43, `docker-bake.hcl`'s `all` group lists it, and `VERSIONING.md` counts it in the image family — *"the ComfyUI images: `complete`, `core`, `runtime`, `mcp`"*. **No job has ever built it.** `mcp:latest` does not exist and never has; the package 403s on anonymous pull.

It went unnoticed because nothing consumes it — Harmony builds its own MCP image from `infrastructure/kubernetes/apps/comfyui-mcp/Dockerfile`.

## The fix

Make the declaration true rather than delete the claim. The target is real, has a dockerfile, and builds — it was simply never wired into CI.

Adds `build-mcp`, gated on `build_images` like the other image jobs, and makes the release job depend on it so a future release cannot resolve digests for an image the run did not build.

No free-disk-space or prune step, unlike the CUDA jobs — this is `python:3.12-slim` plus a git clone.

## Test plan

Built locally, since this image has never been built anywhere:

```
$ docker buildx build --platform linux/amd64 --build-arg MCP_VERSION=v1.1.1 \
    -f services/mcp/dockerfile.comfy.mcp services/mcp
#11 exporting to image ... DONE 7.8s

$ docker run --rm --entrypoint sh mcp-probe:local -c 'ls /app; python -V'
asset_processor.py  CONTRIBUTING.md  LICENSE  NOTICE  README.md
python 3.12.14
```

`PLATFORMS` defaults to `linux/amd64`, so CI builds exactly what was verified here. `actionlint` clean.

## After merge

No release object was created — the failure landed before `gh release create` — so `v0.1.0` is re-cuttable. I'll delete and re-push the tag once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uip6s2MLHkRbDJKhvCmfPk