### PR TITLE
fix(ci): pin the ComfyUI version instead of resolving it at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
 
     - id: classify
       env:
-        GH_TOKEN: ${{ github.token }}
         IMAGES_CHANGED: ${{ needs.changes.outputs.images }}
         FETCH_CHANGED: ${{ needs.changes.outputs.fetch }}
       run: |
@@ -190,9 +189,26 @@ jobs:
           if [ "${FETCH_CHANGED}" = true ]; then build_fetch=true; fi
         fi
 
-        # One upstream lookup for the whole run. Four independent calls could
-        # straddle a ComfyUI release and label one image family differently.
-        comfyui_version="$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)"
+        # What ComfyUI goes INSIDE. Read back out of docker-bake.hcl rather
+        # than grepped, so this and the build cannot disagree about the pin.
+        #
+        # This used to be `gh api .../releases/latest`, which made a release
+        # non-reproducible -- see the COMFYUI_VERSION comment in docker-bake.hcl.
+        comfyui_version="$(docker buildx bake -f docker-bake.hcl --print core-cuda 2>/dev/null \
+          | jq -r '.target["core-cuda"].args.COMFYUI_VERSION')"
+        if [ -z "${comfyui_version}" ] || [ "${comfyui_version}" = null ]; then
+          echo "::error::could not read COMFYUI_VERSION out of docker-bake.hcl"
+          exit 1
+        fi
+
+        # A release has to name a concrete upstream release. `master` is a
+        # moving ref: it would make the release mean something different a week
+        # later, which is the whole failure this pin exists to stop.
+        if [ -n "${image_version}" ] && \
+           ! printf '%s' "${comfyui_version}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::COMFYUI_VERSION is '${comfyui_version}'; a release must pin a concrete upstream version"
+          exit 1
+        fi
         repository_lower="$(printf '%s' "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]' | sed 's/-docker//')"
 
         {
@@ -775,6 +791,7 @@ jobs:
       IMAGE_VERSION: ${{ needs.context.outputs.image_version }}
       FETCH_VERSION: ${{ needs.context.outputs.fetch_version }}
       REGISTRY_URL: ${{ needs.context.outputs.registry_url }}
+      COMFYUI_VERSION: ${{ needs.context.outputs.comfyui_version }}
     steps:
     - uses: actions/checkout@v7.0.1
 
@@ -884,17 +901,28 @@ jobs:
           exit 1
         fi
 
+        # What is inside, stated on the artifact itself. Reading a digest list
+        # and not being able to tell which ComfyUI it carries is how "0.1.0"
+        # becomes a number nobody can interpret.
+        {
+          echo "# ComfyUI ${COMFYUI_VERSION}, packaged as ${IMAGE_VERSION}"
+          echo "#"
+        } > IMAGE-DIGESTS.txt
+
         while read -r tag; do
           digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.Digest}}')"
           printf '%s@%s\n' "${tag%%:*}" "${digest}"
-        done < tags.txt | tee IMAGE-DIGESTS.txt
+        done < tags.txt | tee -a IMAGE-DIGESTS.txt
 
-        n=$(wc -l < IMAGE-DIGESTS.txt); declared=$(wc -l < tags.txt)
+        n=$(grep -c '@sha256:' IMAGE-DIGESTS.txt); declared=$(wc -l < tags.txt)
         if [ "${n}" != "${declared}" ]; then
           echo "::error::resolved ${n} digests for ${declared} tags"
           exit 1
         fi
         {
+          echo ""
+          echo "Contains **ComfyUI ${COMFYUI_VERSION}**. That is what is inside;"
+          echo "\`${IMAGE_VERSION}\` is our packaging version. See VERSIONING.md."
           echo ""
           echo "Pin by digest:"
           echo '```'

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -23,10 +23,19 @@ variable "PLATFORMS" {
 }
 
 variable "COMFYUI_VERSION" {
-    // Repository builds pin a stable upstream source tag by default. Scheduled
-    // publishing resolves the latest upstream release and overrides this.
-    // Set to "master" explicitly for a nightly build.
-    default = "v0.33.1"
+    // THE PIN: which ComfyUI goes inside the images. This file is the single
+    // source of truth, and bumping it is a deliberate, reviewable commit --
+    // the images change, so our own VERSION should move with it.
+    //
+    // CI used to resolve this from Comfy-Org/ComfyUI releases/latest at build
+    // time, which meant a release was not reproducible: v0.1.0 baked whatever
+    // upstream happened to have shipped by the minute the tag ran, a rebuild
+    // would bake something else, and a local build used the default here --
+    // three different meanings for one tag.
+    //
+    // Tracking upstream is what the weekly rebuild is for; it still resolves
+    // latest, on purpose, and publishes under its own labels.
+    default = "v0.34.0"
 }
 
 variable "IMAGE_VERSION" {
@@ -52,8 +61,10 @@ variable "PUBLISH_LATEST" {
 }
 
 variable "SAGEATTENTION_RELEASE_URL" {
-    // Immutable release produced from thu-ml/SageAttention v2.2.0 for the
-    // Python, PyTorch, and CUDA ABI used by the current CUDA image.
+    // Release produced from thu-ml/SageAttention v2.2.0 for the Python,
+    // PyTorch, and CUDA ABI used by the current CUDA image. NOT immutable --
+    // that release can be re-uploaded in place, which is why every wheel below
+    // is pinned by URL *and* checked against a recorded sha256.
     default = "https://github.com/pixeloven/SageAttention-Wheels/releases/download/sageattention-v2.2.0-cu130-torch2.13.0"
 }
 


### PR DESCRIPTION
Closes the gap you spotted on `v0.1.0`: the release doesn't say what ComfyUI it contains, and it can't be rebuilt.

## One line caused both

```yaml
comfyui_version="$(gh api repos/Comfy-Org/ComfyUI/releases/latest --jq .tag_name)"
```

Resolved at build time, so one tag had three meanings:

| built | ComfyUI baked in |
|---|---|
| the `v0.1.0` release | **v0.34.0** — whatever upstream had shipped by the minute the tag ran |
| a rebuild tomorrow | whatever is latest *then* |
| a local build | **v0.33.1** — `docker-bake.hcl`'s stale default |

And nothing recorded which. The answer *existed* — `core:cuda-0.1.0` and `core:cuda-v0.34.0` are byte-identical (`e05f71c2…`) — but only by inspecting the registry and comparing digests. The release notes and `IMAGE-DIGESTS.txt` were both silent.

## The fix

`docker-bake.hcl` becomes the single source of truth, set to the **v0.34.0** that `0.1.0` actually shipped. CI reads it back via `bake --print` rather than grepping, so the value CI reports and the value the build uses cannot drift.

Tracking upstream is what **`weekly.yml` ("Weekly Fresh Rebuild")** is for — it still resolves latest on purpose, and is now the only place that does.

Two things the release can now say:

- `IMAGE-DIGESTS.txt` opens with `# ComfyUI v0.34.0, packaged as 0.1.0`
- The notes state the ComfyUI version and name it as distinct from ours

One thing it now refuses: a `v*` tag with a non-concrete pin. `master` is a moving ref — a release built from it means something different a week later, which is the failure this exists to prevent. `master` stays legal off a release tag, which is what nightly builds want.

Also corrects `docker-bake.hcl`'s comment calling the SageAttention release "Immutable". It isn't, and we've deliberately chosen not to make it so — which is exactly why every wheel there is pinned by URL **and** verified against a recorded sha256.

## Test plan

Simulated the classify step against the real bake file:

```
pin = v0.34.0
  refs/heads/main              rc=0  comfyui_version=v0.34.0
  refs/tags/v0.1.0             rc=0  comfyui_version=v0.34.0  image_label=0.1.0
  refs/tags/comfyfetch/v0.2.0  rc=0  comfyui_version=v0.34.0

pin = master
  refs/heads/main              rc=0  comfyui_version=master        <- still fine
  refs/tags/v0.1.0             rc=1  "COMFYUI_VERSION is 'master'; a release
                                      must pin a concrete upstream version"
```

`actionlint` clean.

## Note on the published v0.1.0

It already contains ComfyUI v0.34.0; only the *record* was missing. I'll add that line to its release notes separately — the images are untouched.

Upstream is currently at v0.34.0, so this pin is not behind. Bumping it later is now a deliberate commit, and per `VERSIONING.md` should move our `VERSION` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uip6s2MLHkRbDJKhvCmfPk