### PR TITLE
fix(ci): stop overriding the registry cache with the Actions cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,12 @@ jobs:
         docker-images: true
         swap-storage: true
 
+    - name: Clean Docker Images
+      run: |
+        echo "🧹 Removing Docker system..."
+        sudo docker system prune -af --volumes || true
+        echo "✅ Docker system cleaned"
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4.3.0
       with:
@@ -745,6 +751,12 @@ jobs:
         large-packages: true
         docker-images: true
         swap-storage: true
+
+    - name: Clean Docker Images
+      run: |
+        echo "🧹 Removing Docker system..."
+        sudo docker system prune -af --volumes || true
+        echo "✅ Docker system cleaned"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,9 +556,18 @@ jobs:
         push: ${{ github.event_name == 'push' }}
         no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        set: |
-          *.cache-from=type=gha
-          *.cache-to=type=gha,mode=max
+        # No gha cache override here. docker-bake.hcl already declares a
+        # REGISTRY cache for these targets, and the override replaced it with
+        # the Actions cache -- which is capped at 10 GB per repo, while
+        # `mode=max` pushes every intermediate layer of five multi-GB CUDA
+        # images into it. It thrashes, evicts mid-build, and the next blob
+        # fetch fails:
+        #
+        #   ERROR: target complete-cuda-sm90: failed to solve: failed to copy:
+        #   GET https://productionresultssa10.blob.core.windows.net/actions-cache/...
+        #
+        # which is what killed the v1.0.0 release (sm86) and its retry (sm90).
+        # The registry cache is unlimited and shared across runs.
         provenance: false
         sbom: false
       env:
@@ -613,9 +622,18 @@ jobs:
         push: ${{ github.event_name == 'push' }}
         no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        set: |
-          *.cache-from=type=gha
-          *.cache-to=type=gha,mode=max
+        # No gha cache override here. docker-bake.hcl already declares a
+        # REGISTRY cache for these targets, and the override replaced it with
+        # the Actions cache -- which is capped at 10 GB per repo, while
+        # `mode=max` pushes every intermediate layer of five multi-GB CUDA
+        # images into it. It thrashes, evicts mid-build, and the next blob
+        # fetch fails:
+        #
+        #   ERROR: target complete-cuda-sm90: failed to solve: failed to copy:
+        #   GET https://productionresultssa10.blob.core.windows.net/actions-cache/...
+        #
+        # which is what killed the v1.0.0 release (sm86) and its retry (sm90).
+        # The registry cache is unlimited and shared across runs.
         provenance: false
         sbom: false
       env:
@@ -716,9 +734,18 @@ jobs:
         push: ${{ github.event_name == 'push' }}
         no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        set: |
-          *.cache-from=type=gha
-          *.cache-to=type=gha,mode=max
+        # No gha cache override here. docker-bake.hcl already declares a
+        # REGISTRY cache for these targets, and the override replaced it with
+        # the Actions cache -- which is capped at 10 GB per repo, while
+        # `mode=max` pushes every intermediate layer of five multi-GB CUDA
+        # images into it. It thrashes, evicts mid-build, and the next blob
+        # fetch fails:
+        #
+        #   ERROR: target complete-cuda-sm90: failed to solve: failed to copy:
+        #   GET https://productionresultssa10.blob.core.windows.net/actions-cache/...
+        #
+        # which is what killed the v1.0.0 release (sm86) and its retry (sm90).
+        # The registry cache is unlimited and shared across runs.
         provenance: false
         sbom: false
       env:
@@ -776,9 +803,8 @@ jobs:
         push: ${{ github.event_name == 'push' }}
         no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        set: |
-          *.cache-from=type=gha,scope=${{ matrix.target }}
-          *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}
+        # No gha override: bake declares a REGISTRY cache for these, and the
+        # Actions cache is capped at 10 GB per repo. See build-cuda-arch.
         provenance: false
         sbom: false
       env:


### PR DESCRIPTION
`v1.0.0` failed in `build-cuda-arch`:

```
failed to write compressed diff: mount callback failed on /tmp/containerd-mount2265063111
```

Runner out of disk. The job it hit isn't a coincidence:

| job | targets built | free-disk | prune |
|---|---|---|---|
| `build-cuda` | 3 | yes | yes |
| **`build-cuda-arch`** | **7** | yes | **no** |
| `build-cpu` | 2 | yes | yes |
| `build-linux-accelerators` | 2 | yes | **no** |

`build-cuda-arch` builds more than twice as many images as any other job — five architecture-specific `complete` variants, each a full CUDA stack plus its SageAttention wheel — and it was the one job with no `docker system prune`. The two *smallest* jobs had one.

The misleading part is that it passed on the `v0.1.0` release. It succeeded by margin, not by design, so nothing signalled the job was one cache-miss away from failing.

Adds the prune to both jobs that lacked it.

## No half-published release

The failure landed **before** `cut the release`, so no release object exists and `v1.0.0` is cleanly re-cuttable. That step ordering has now paid for itself twice — the first time was the missing `mcp` image.

After this merges I'll delete and re-push `v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uip6s2MLHkRbDJKhvCmfPk